### PR TITLE
circle: fix build failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lint:
 
 .PHONY: setup
 setup:
-	$(NPM) update
+	$(NPM) install
 
 
 .PHONY: test

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 dependencies:
   override:
+    - rm -rf node_modules
     - make setup
 
 machine:


### PR DESCRIPTION
There's one simple rule to caching: never cache anything that can change.

My faith in npm's ability to cache things in a sane manner is zero. My faith in CircleCI's abilities is not much higher. I don't know who's to blame for the recent test failures, nor am I interested in spending the time to discover the answer. `rm -rf node_modules` will allow us to devote our time and attention to more important matters.
