### PR TITLE
change code from blue to pink

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
 
 code {
   font-family: "Courier", monospace;
-  color: #369;
+  color: #c36;
 }
 
 a {
@@ -167,7 +167,7 @@ pre {
 }
 
 .examples .output[data-error="true"] {
-  color: #c20;
+  color: #c36;
 }
 
 .tight + .tight {


### PR DESCRIPTION
Identifiers such as `(<*)` stand out much more in pink than they do in blue. The pink is the same colour used in the top banner. I changed the error colour from red to pink as red and pink do not look good together.
