### PR TITLE
Use non-breaking hyphens in function arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         <a href="#api">API</a>
         <ul>
           <li>
-            <a href="#create"><code><b>create</b> <span class="tight">:</span><span class="tight">:</span> { checkTypes <span class="tight">:</span><span class="tight">:</span> Boolean, env <span class="tight">:</span><span class="tight">:</span> Array Type } <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Module</code></a>
+            <a href="#create"><code><b>create</b> <span class="tight">:</span><span class="tight">:</span> { checkTypes <span class="tight">:</span><span class="tight">:</span> Boolean, env <span class="tight">:</span><span class="tight">:</span> Array Type } <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Module</code></a>
           </li>
           <li>
             <a href="#env"><code><b>env</b> <span class="tight">:</span><span class="tight">:</span> Array Type</code></a>
@@ -68,10 +68,10 @@
             <a href="#classify">Classify</a>
             <ul>
               <li>
-                <a href="#type"><code><b>type</b> <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#type"><code><b>type</b> <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#is"><code><b>is</b> <span class="tight">:</span><span class="tight">:</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#is"><code><b>is</b> <span class="tight">:</span><span class="tight">:</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Any <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
             </ul>
           </li>
@@ -79,7 +79,7 @@
             <a href="#showable">Showable</a>
             <ul>
               <li>
-                <a href="#toString"><code><b>toString</b> <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#toString"><code><b>toString</b> <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
             </ul>
           </li>
@@ -87,79 +87,79 @@
             <a href="#fantasy-land">Fantasy Land</a>
             <ul>
               <li>
-                <a href="#equals"><code><b>equals</b> <span class="tight">:</span><span class="tight">:</span> Setoid a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#equals"><code><b>equals</b> <span class="tight">:</span><span class="tight">:</span> Setoid a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#concat"><code><b>concat</b> <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></a>
+                <a href="#concat"><code><b>concat</b> <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></a>
               </li>
               <li>
-                <a href="#empty"><code><b>empty</b> <span class="tight">:</span><span class="tight">:</span> Monoid a <span class="arrow">=&gt;</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></a>
+                <a href="#empty"><code><b>empty</b> <span class="tight">:</span><span class="tight">:</span> Monoid a <span class="arrow">=&gt;</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></a>
               </li>
               <li>
-                <a href="#map"><code><b>map</b> <span class="tight">:</span><span class="tight">:</span> Functor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b</code></a>
+                <a href="#map"><code><b>map</b> <span class="tight">:</span><span class="tight">:</span> Functor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b</code></a>
               </li>
               <li>
-                <a href="#bimap"><code><b>bimap</b> <span class="tight">:</span><span class="tight">:</span> Bifunctor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b d</code></a>
+                <a href="#bimap"><code><b>bimap</b> <span class="tight">:</span><span class="tight">:</span> Bifunctor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b d</code></a>
               </li>
               <li>
-                <a href="#promap"><code><b>promap</b> <span class="tight">:</span><span class="tight">:</span> Profunctor p <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> p b c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> p a d</code></a>
+                <a href="#promap"><code><b>promap</b> <span class="tight">:</span><span class="tight">:</span> Profunctor p <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> p b c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> p a d</code></a>
               </li>
               <li>
-                <a href="#alt"><code><b>alt</b> <span class="tight">:</span><span class="tight">:</span> Alt f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a</code></a>
+                <a href="#alt"><code><b>alt</b> <span class="tight">:</span><span class="tight">:</span> Alt f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a</code></a>
               </li>
               <li>
-                <a href="#zero"><code><b>zero</b> <span class="tight">:</span><span class="tight">:</span> Plus f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a</code></a>
+                <a href="#zero"><code><b>zero</b> <span class="tight">:</span><span class="tight">:</span> Plus f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a</code></a>
               </li>
               <li>
-                <a href="#reduce"><code><b>reduce</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#reduce"><code><b>reduce</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
               <li>
-                <a href="#reduce_"><code><b>reduce_</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#reduce_"><code><b>reduce_</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
               <li>
-                <a href="#traverse"><code><b>traverse</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> t a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f (t b)</code></a>
+                <a href="#traverse"><code><b>traverse</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> t a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f (t b)</code></a>
               </li>
               <li>
-                <a href="#sequence"><code><b>sequence</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> t (f a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f (t a)</code></a>
+                <a href="#sequence"><code><b>sequence</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> t (f a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f (t a)</code></a>
               </li>
               <li>
-                <a href="#ap"><code><b>ap</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b</code></a>
+                <a href="#ap"><code><b>ap</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b</code></a>
               </li>
               <li>
-                <a href="#lift2"><code><b>lift2</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f c</code></a>
+                <a href="#lift2"><code><b>lift2</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f c</code></a>
               </li>
               <li>
-                <a href="#lift3"><code><b>lift3</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f d</code></a>
+                <a href="#lift3"><code><b>lift3</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f d</code></a>
               </li>
               <li>
-                <a href="#apFirst"><code><b>apFirst</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a</code></a>
+                <a href="#apFirst"><code><b>apFirst</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a</code></a>
               </li>
               <li>
-                <a href="#apSecond"><code><b>apSecond</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b</code></a>
+                <a href="#apSecond"><code><b>apSecond</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b</code></a>
               </li>
               <li>
-                <a href="#of"><code><b>of</b> <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a</code></a>
+                <a href="#of"><code><b>of</b> <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a</code></a>
               </li>
               <li>
-                <a href="#chain"><code><b>chain</b> <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m b</code></a>
+                <a href="#chain"><code><b>chain</b> <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m b</code></a>
               </li>
               <li>
-                <a href="#join"><code><b>join</b> <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> m (m a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m a</code></a>
+                <a href="#join"><code><b>join</b> <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> m (m a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m a</code></a>
               </li>
               <li>
-                <a href="#chainRec"><code><b>chainRec</b> <span class="tight">:</span><span class="tight">:</span> ChainRec m <span class="arrow">=&gt;</span> TypeRep m <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m (Either a b)) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m b</code></a>
+                <a href="#chainRec"><code><b>chainRec</b> <span class="tight">:</span><span class="tight">:</span> ChainRec m <span class="arrow">=&gt;</span> TypeRep m <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m (Either a b)) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m b</code></a>
               </li>
               <li>
-                <a href="#extend"><code><b>extend</b> <span class="tight">:</span><span class="tight">:</span> Extend w <span class="arrow">=&gt;</span> (w a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> w b</code></a>
+                <a href="#extend"><code><b>extend</b> <span class="tight">:</span><span class="tight">:</span> Extend w <span class="arrow">=&gt;</span> (w a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> w b</code></a>
               </li>
               <li>
-                <a href="#extract"><code><b>extract</b> <span class="tight">:</span><span class="tight">:</span> Comonad w <span class="arrow">=&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></a>
+                <a href="#extract"><code><b>extract</b> <span class="tight">:</span><span class="tight">:</span> Comonad w <span class="arrow">=&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></a>
               </li>
               <li>
-                <a href="#filter"><code><b>filter</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Foldable f, Monoid (f a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a</code></a>
+                <a href="#filter"><code><b>filter</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Foldable f, Monoid (f a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a</code></a>
               </li>
               <li>
-                <a href="#filterM"><code><b>filterM</b> <span class="tight">:</span><span class="tight">:</span> (Monad m, Monoid (m a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m a</code></a>
+                <a href="#filterM"><code><b>filterM</b> <span class="tight">:</span><span class="tight">:</span> (Monad m, Monoid (m a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m a</code></a>
               </li>
             </ul>
           </li>
@@ -167,16 +167,16 @@
             <a href="#combinator">Combinator</a>
             <ul>
               <li>
-                <a href="#I"><code><b>I</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></a>
+                <a href="#I"><code><b>I</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></a>
               </li>
               <li>
-                <a href="#K"><code><b>K</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></a>
+                <a href="#K"><code><b>K</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></a>
               </li>
               <li>
-                <a href="#A"><code><b>A</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#A"><code><b>A</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
               <li>
-                <a href="#T"><code><b>T</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#T"><code><b>T</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
             </ul>
           </li>
@@ -184,22 +184,22 @@
             <a href="#function">Function</a>
             <ul>
               <li>
-                <a href="#curry2"><code><b>curry2</b> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</code></a>
+                <a href="#curry2"><code><b>curry2</b> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</code></a>
               </li>
               <li>
-                <a href="#curry3"><code><b>curry3</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d</code></a>
+                <a href="#curry3"><code><b>curry3</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d</code></a>
               </li>
               <li>
-                <a href="#curry4"><code><b>curry4</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> e) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> e</code></a>
+                <a href="#curry4"><code><b>curry4</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> e) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> e</code></a>
               </li>
               <li>
-                <a href="#curry5"><code><b>curry5</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d, e) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> e <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f</code></a>
+                <a href="#curry5"><code><b>curry5</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d, e) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> e <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f</code></a>
               </li>
               <li>
-                <a href="#flip"><code><b>flip</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</code></a>
+                <a href="#flip"><code><b>flip</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</code></a>
               </li>
               <li>
-                <a href="#flip_"><code><b>flip_</b> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</code></a>
+                <a href="#flip_"><code><b>flip_</b> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</code></a>
               </li>
             </ul>
           </li>
@@ -207,16 +207,16 @@
             <a href="#composition">Composition</a>
             <ul>
               <li>
-                <a href="#compose"><code><b>compose</b> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</code></a>
+                <a href="#compose"><code><b>compose</b> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</code></a>
               </li>
               <li>
-                <a href="#pipe"><code><b>pipe</b> <span class="tight">:</span><span class="tight">:</span> [(a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b), (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c), <span class="tight">.</span><span class="tight">.</span><span class="tight">.</span>, (m <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> n)] <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> n</code></a>
+                <a href="#pipe"><code><b>pipe</b> <span class="tight">:</span><span class="tight">:</span> [(a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b), (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c), <span class="tight">.</span><span class="tight">.</span><span class="tight">.</span>, (m <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> n)] <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> n</code></a>
               </li>
               <li>
-                <a href="#on"><code><b>on</b> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</code></a>
+                <a href="#on"><code><b>on</b> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</code></a>
               </li>
               <li>
-                <a href="#on_"><code><b>on_</b> <span class="tight">:</span><span class="tight">:</span> ((b, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</code></a>
+                <a href="#on_"><code><b>on_</b> <span class="tight">:</span><span class="tight">:</span> ((b, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</code></a>
               </li>
             </ul>
           </li>
@@ -224,7 +224,7 @@
             <a href="#maybe-type">Maybe type</a>
             <ul>
               <li>
-                <a href="#MaybeType"><code><b>MaybeType</b> <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Type</code></a>
+                <a href="#MaybeType"><code><b>MaybeType</b> <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Type</code></a>
               </li>
               <li>
                 <a href="#Maybe"><code><b>Maybe</b> <span class="tight">:</span><span class="tight">:</span> TypeRep Maybe</code></a>
@@ -233,19 +233,19 @@
                 <a href="#Nothing"><code><b>Nothing</b> <span class="tight">:</span><span class="tight">:</span> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Just"><code><b>Just</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#Just"><code><b>Just</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
                 <a href="#Maybe.@@type"><code><b>Maybe.@@type</b> <span class="tight">:</span><span class="tight">:</span> String</code></a>
               </li>
               <li>
-                <a href="#Maybe.fantasy-land/empty"><code><b>Maybe.fantasy-land/empty</b> <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#Maybe.fantasy-land/empty"><code><b>Maybe.fantasy-land/empty</b> <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Maybe.fantasy-land/of"><code><b>Maybe.fantasy-land/of</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#Maybe.fantasy-land/of"><code><b>Maybe.fantasy-land/of</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Maybe.fantasy-land/zero"><code><b>Maybe.fantasy-land/zero</b> <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#Maybe.fantasy-land/zero"><code><b>Maybe.fantasy-land/zero</b> <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
                 <a href="#Maybe.prototype.isNothing"><code><b>Maybe#isNothing</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Boolean</code></a>
@@ -254,85 +254,85 @@
                 <a href="#Maybe.prototype.isJust"><code><b>Maybe#isJust</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.toString"><code><b>Maybe#toString</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#Maybe.prototype.toString"><code><b>Maybe#toString</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.inspect"><code><b>Maybe#inspect</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#Maybe.prototype.inspect"><code><b>Maybe#inspect</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/equals"><code><b>Maybe#fantasy-land/equals</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#Maybe.prototype.fantasy-land/equals"><code><b>Maybe#fantasy-land/equals</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/concat"><code><b>Maybe#fantasy-land/concat</b> <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#Maybe.prototype.fantasy-land/concat"><code><b>Maybe#fantasy-land/concat</b> <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/map"><code><b>Maybe#fantasy-land/map</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</code></a>
+                <a href="#Maybe.prototype.fantasy-land/map"><code><b>Maybe#fantasy-land/map</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/ap"><code><b>Maybe#fantasy-land/ap</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</code></a>
+                <a href="#Maybe.prototype.fantasy-land/ap"><code><b>Maybe#fantasy-land/ap</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/chain"><code><b>Maybe#fantasy-land/chain</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</code></a>
+                <a href="#Maybe.prototype.fantasy-land/chain"><code><b>Maybe#fantasy-land/chain</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/alt"><code><b>Maybe#fantasy-land/alt</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#Maybe.prototype.fantasy-land/alt"><code><b>Maybe#fantasy-land/alt</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/reduce"><code><b>Maybe#fantasy-land/reduce</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#Maybe.prototype.fantasy-land/reduce"><code><b>Maybe#fantasy-land/reduce</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/traverse"><code><b>Maybe#fantasy-land/traverse</b> <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> (TypeRep f, a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f (Maybe b)</code></a>
+                <a href="#Maybe.prototype.fantasy-land/traverse"><code><b>Maybe#fantasy-land/traverse</b> <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> (TypeRep f, a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f (Maybe b)</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/extend"><code><b>Maybe#fantasy-land/extend</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</code></a>
+                <a href="#Maybe.prototype.fantasy-land/extend"><code><b>Maybe#fantasy-land/extend</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</code></a>
               </li>
               <li>
-                <a href="#isNothing"><code><b>isNothing</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#isNothing"><code><b>isNothing</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#isJust"><code><b>isJust</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#isJust"><code><b>isJust</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#fromMaybe"><code><b>fromMaybe</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></a>
+                <a href="#fromMaybe"><code><b>fromMaybe</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></a>
               </li>
               <li>
-                <a href="#fromMaybe_"><code><b>fromMaybe_</b> <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></a>
+                <a href="#fromMaybe_"><code><b>fromMaybe_</b> <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></a>
               </li>
               <li>
-                <a href="#maybeToNullable"><code><b>maybeToNullable</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Nullable a</code></a>
+                <a href="#maybeToNullable"><code><b>maybeToNullable</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Nullable a</code></a>
               </li>
               <li>
-                <a href="#toMaybe"><code><b>toMaybe</b> <span class="tight">:</span><span class="tight">:</span> a? <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#toMaybe"><code><b>toMaybe</b> <span class="tight">:</span><span class="tight">:</span> a? <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
-                <a href="#maybe"><code><b>maybe</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#maybe"><code><b>maybe</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
               <li>
-                <a href="#maybe_"><code><b>maybe_</b> <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#maybe_"><code><b>maybe_</b> <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
               <li>
-                <a href="#justs"><code><b>justs</b> <span class="tight">:</span><span class="tight">:</span> Array (Maybe a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</code></a>
+                <a href="#justs"><code><b>justs</b> <span class="tight">:</span><span class="tight">:</span> Array (Maybe a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</code></a>
               </li>
               <li>
-                <a href="#mapMaybe"><code><b>mapMaybe</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array b</code></a>
+                <a href="#mapMaybe"><code><b>mapMaybe</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array b</code></a>
               </li>
               <li>
-                <a href="#encase"><code><b>encase</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</code></a>
+                <a href="#encase"><code><b>encase</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</code></a>
               </li>
               <li>
-                <a href="#encase2"><code><b>encase2</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe c</code></a>
+                <a href="#encase2"><code><b>encase2</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe c</code></a>
               </li>
               <li>
-                <a href="#encase2_"><code><b>encase2_</b> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe c</code></a>
+                <a href="#encase2_"><code><b>encase2_</b> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe c</code></a>
               </li>
               <li>
-                <a href="#encase3"><code><b>encase3</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe d</code></a>
+                <a href="#encase3"><code><b>encase3</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe d</code></a>
               </li>
               <li>
-                <a href="#encase3_"><code><b>encase3_</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe d</code></a>
+                <a href="#encase3_"><code><b>encase3_</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe d</code></a>
               </li>
               <li>
-                <a href="#maybeToEither"><code><b>maybeToEither</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</code></a>
+                <a href="#maybeToEither"><code><b>maybeToEither</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</code></a>
               </li>
             </ul>
           </li>
@@ -340,22 +340,22 @@
             <a href="#either-type">Either type</a>
             <ul>
               <li>
-                <a href="#EitherType"><code><b>EitherType</b> <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Type</code></a>
+                <a href="#EitherType"><code><b>EitherType</b> <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Type <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Type</code></a>
               </li>
               <li>
                 <a href="#Either"><code><b>Either</b> <span class="tight">:</span><span class="tight">:</span> TypeRep Either</code></a>
               </li>
               <li>
-                <a href="#Left"><code><b>Left</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</code></a>
+                <a href="#Left"><code><b>Left</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</code></a>
               </li>
               <li>
-                <a href="#Right"><code><b>Right</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</code></a>
+                <a href="#Right"><code><b>Right</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</code></a>
               </li>
               <li>
                 <a href="#Either.@@type"><code><b>Either.@@type</b> <span class="tight">:</span><span class="tight">:</span> String</code></a>
               </li>
               <li>
-                <a href="#Either.fantasy-land/of"><code><b>Either.fantasy-land/of</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</code></a>
+                <a href="#Either.fantasy-land/of"><code><b>Either.fantasy-land/of</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</code></a>
               </li>
               <li>
                 <a href="#Either.prototype.isLeft"><code><b>Either#isLeft</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Boolean</code></a>
@@ -364,79 +364,79 @@
                 <a href="#Either.prototype.isRight"><code><b>Either#isRight</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.toString"><code><b>Either#toString</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#Either.prototype.toString"><code><b>Either#toString</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.inspect"><code><b>Either#inspect</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#Either.prototype.inspect"><code><b>Either#inspect</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/equals"><code><b>Either#fantasy-land/equals</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#Either.prototype.fantasy-land/equals"><code><b>Either#fantasy-land/equals</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/concat"><code><b>Either#fantasy-land/concat</b> <span class="tight">:</span><span class="tight">:</span> (Semigroup a, Semigroup b) <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</code></a>
+                <a href="#Either.prototype.fantasy-land/concat"><code><b>Either#fantasy-land/concat</b> <span class="tight">:</span><span class="tight">:</span> (Semigroup a, Semigroup b) <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/map"><code><b>Either#fantasy-land/map</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a c</code></a>
+                <a href="#Either.prototype.fantasy-land/map"><code><b>Either#fantasy-land/map</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a c</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/bimap"><code><b>Either#fantasy-land/bimap</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c, b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either c d</code></a>
+                <a href="#Either.prototype.fantasy-land/bimap"><code><b>Either#fantasy-land/bimap</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c, b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either c d</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/ap"><code><b>Either#fantasy-land/ap</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a c</code></a>
+                <a href="#Either.prototype.fantasy-land/ap"><code><b>Either#fantasy-land/ap</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a c</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/chain"><code><b>Either#fantasy-land/chain</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a c</code></a>
+                <a href="#Either.prototype.fantasy-land/chain"><code><b>Either#fantasy-land/chain</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a c</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/alt"><code><b>Either#fantasy-land/alt</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</code></a>
+                <a href="#Either.prototype.fantasy-land/alt"><code><b>Either#fantasy-land/alt</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/reduce"><code><b>Either#fantasy-land/reduce</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> ((c, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c, c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</code></a>
+                <a href="#Either.prototype.fantasy-land/reduce"><code><b>Either#fantasy-land/reduce</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> ((c, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c, c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/traverse"><code><b>Either#fantasy-land/traverse</b> <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> (TypeRep f, b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f (Either a c)</code></a>
+                <a href="#Either.prototype.fantasy-land/traverse"><code><b>Either#fantasy-land/traverse</b> <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> (TypeRep f, b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f (Either a c)</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/extend"><code><b>Either#fantasy-land/extend</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a c</code></a>
+                <a href="#Either.prototype.fantasy-land/extend"><code><b>Either#fantasy-land/extend</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a c</code></a>
               </li>
               <li>
-                <a href="#isLeft"><code><b>isLeft</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#isLeft"><code><b>isLeft</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#isRight"><code><b>isRight</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#isRight"><code><b>isRight</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#fromEither"><code><b>fromEither</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#fromEither"><code><b>fromEither</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
               <li>
-                <a href="#toEither"><code><b>toEither</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b? <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</code></a>
+                <a href="#toEither"><code><b>toEither</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b? <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</code></a>
               </li>
               <li>
-                <a href="#either"><code><b>either</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</code></a>
+                <a href="#either"><code><b>either</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</code></a>
               </li>
               <li>
-                <a href="#lefts"><code><b>lefts</b> <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</code></a>
+                <a href="#lefts"><code><b>lefts</b> <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</code></a>
               </li>
               <li>
-                <a href="#rights"><code><b>rights</b> <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array b</code></a>
+                <a href="#rights"><code><b>rights</b> <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array b</code></a>
               </li>
               <li>
-                <a href="#encaseEither"><code><b>encaseEither</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either l r</code></a>
+                <a href="#encaseEither"><code><b>encaseEither</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either l r</code></a>
               </li>
               <li>
-                <a href="#encaseEither2"><code><b>encaseEither2</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either l r</code></a>
+                <a href="#encaseEither2"><code><b>encaseEither2</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either l r</code></a>
               </li>
               <li>
-                <a href="#encaseEither2_"><code><b>encaseEither2_</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either l r</code></a>
+                <a href="#encaseEither2_"><code><b>encaseEither2_</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either l r</code></a>
               </li>
               <li>
-                <a href="#encaseEither3"><code><b>encaseEither3</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either l r</code></a>
+                <a href="#encaseEither3"><code><b>encaseEither3</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either l r</code></a>
               </li>
               <li>
-                <a href="#encaseEither3_"><code><b>encaseEither3_</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either l r</code></a>
+                <a href="#encaseEither3_"><code><b>encaseEither3_</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either l r</code></a>
               </li>
               <li>
-                <a href="#eitherToMaybe"><code><b>eitherToMaybe</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</code></a>
+                <a href="#eitherToMaybe"><code><b>eitherToMaybe</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</code></a>
               </li>
             </ul>
           </li>
@@ -444,22 +444,22 @@
             <a href="#logic">Logic</a>
             <ul>
               <li>
-                <a href="#and"><code><b>and</b> <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#and"><code><b>and</b> <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#or"><code><b>or</b> <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#or"><code><b>or</b> <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#not"><code><b>not</b> <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#not"><code><b>not</b> <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#ifElse"><code><b>ifElse</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#ifElse"><code><b>ifElse</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
               <li>
-                <a href="#allPass"><code><b>allPass</b> <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#allPass"><code><b>allPass</b> <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#anyPass"><code><b>anyPass</b> <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#anyPass"><code><b>anyPass</b> <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
             </ul>
           </li>
@@ -467,46 +467,46 @@
             <a href="#list">List</a>
             <ul>
               <li>
-                <a href="#concat"><code><b>concat</b> <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></a>
+                <a href="#concat"><code><b>concat</b> <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></a>
               </li>
               <li>
-                <a href="#slice"><code><b>slice</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</code></a>
+                <a href="#slice"><code><b>slice</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#at"><code><b>at</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#at"><code><b>at</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
-                <a href="#head"><code><b>head</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#head"><code><b>head</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
-                <a href="#last"><code><b>last</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#last"><code><b>last</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
-                <a href="#tail"><code><b>tail</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</code></a>
+                <a href="#tail"><code><b>tail</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#init"><code><b>init</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</code></a>
+                <a href="#init"><code><b>init</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#take"><code><b>take</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</code></a>
+                <a href="#take"><code><b>take</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#takeLast"><code><b>takeLast</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</code></a>
+                <a href="#takeLast"><code><b>takeLast</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#drop"><code><b>drop</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</code></a>
+                <a href="#drop"><code><b>drop</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#dropLast"><code><b>dropLast</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</code></a>
+                <a href="#dropLast"><code><b>dropLast</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#reverse"><code><b>reverse</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a</code></a>
+                <a href="#reverse"><code><b>reverse</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a</code></a>
               </li>
               <li>
-                <a href="#indexOf"><code><b>indexOf</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe Integer</code></a>
+                <a href="#indexOf"><code><b>indexOf</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe Integer</code></a>
               </li>
               <li>
-                <a href="#lastIndexOf"><code><b>lastIndexOf</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe Integer</code></a>
+                <a href="#lastIndexOf"><code><b>lastIndexOf</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe Integer</code></a>
               </li>
             </ul>
           </li>
@@ -514,25 +514,25 @@
             <a href="#array">Array</a>
             <ul>
               <li>
-                <a href="#append"><code><b>append</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</code></a>
+                <a href="#append"><code><b>append</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</code></a>
               </li>
               <li>
-                <a href="#prepend"><code><b>prepend</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</code></a>
+                <a href="#prepend"><code><b>prepend</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</code></a>
               </li>
               <li>
-                <a href="#joinWith"><code><b>joinWith</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#joinWith"><code><b>joinWith</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#find"><code><b>find</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</code></a>
+                <a href="#find"><code><b>find</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</code></a>
               </li>
               <li>
-                <a href="#pluck"><code><b>pluck</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array b</code></a>
+                <a href="#pluck"><code><b>pluck</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array b</code></a>
               </li>
               <li>
-                <a href="#unfoldr"><code><b>unfoldr</b> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (Pair a b)) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</code></a>
+                <a href="#unfoldr"><code><b>unfoldr</b> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (Pair a b)) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</code></a>
               </li>
               <li>
-                <a href="#range"><code><b>range</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array Integer</code></a>
+                <a href="#range"><code><b>range</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array Integer</code></a>
               </li>
             </ul>
           </li>
@@ -540,25 +540,25 @@
             <a href="#object">Object</a>
             <ul>
               <li>
-                <a href="#prop"><code><b>prop</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#prop"><code><b>prop</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
               <li>
-                <a href="#props"><code><b>props</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code></a>
+                <a href="#props"><code><b>props</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code></a>
               </li>
               <li>
-                <a href="#get"><code><b>get</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe c</code></a>
+                <a href="#get"><code><b>get</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe c</code></a>
               </li>
               <li>
-                <a href="#gets"><code><b>gets</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe c</code></a>
+                <a href="#gets"><code><b>gets</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe c</code></a>
               </li>
               <li>
-                <a href="#keys"><code><b>keys</b> <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String</code></a>
+                <a href="#keys"><code><b>keys</b> <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String</code></a>
               </li>
               <li>
-                <a href="#values"><code><b>values</b> <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</code></a>
+                <a href="#values"><code><b>values</b> <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</code></a>
               </li>
               <li>
-                <a href="#pairs"><code><b>pairs</b> <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array (Pair String a)</code></a>
+                <a href="#pairs"><code><b>pairs</b> <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array (Pair String a)</code></a>
               </li>
             </ul>
           </li>
@@ -566,40 +566,40 @@
             <a href="#number">Number</a>
             <ul>
               <li>
-                <a href="#negate"><code><b>negate</b> <span class="tight">:</span><span class="tight">:</span> ValidNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> ValidNumber</code></a>
+                <a href="#negate"><code><b>negate</b> <span class="tight">:</span><span class="tight">:</span> ValidNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> ValidNumber</code></a>
               </li>
               <li>
-                <a href="#add"><code><b>add</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</code></a>
+                <a href="#add"><code><b>add</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#sum"><code><b>sum</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</code></a>
+                <a href="#sum"><code><b>sum</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#sub"><code><b>sub</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</code></a>
+                <a href="#sub"><code><b>sub</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#inc"><code><b>inc</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</code></a>
+                <a href="#inc"><code><b>inc</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#dec"><code><b>dec</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</code></a>
+                <a href="#dec"><code><b>dec</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#mult"><code><b>mult</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</code></a>
+                <a href="#mult"><code><b>mult</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#product"><code><b>product</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</code></a>
+                <a href="#product"><code><b>product</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#div"><code><b>div</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> NonZeroFiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</code></a>
+                <a href="#div"><code><b>div</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> NonZeroFiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#mean"><code><b>mean</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe FiniteNumber</code></a>
+                <a href="#mean"><code><b>mean</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#min"><code><b>min</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></a>
+                <a href="#min"><code><b>min</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></a>
               </li>
               <li>
-                <a href="#max"><code><b>max</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></a>
+                <a href="#max"><code><b>max</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></a>
               </li>
             </ul>
           </li>
@@ -607,10 +607,10 @@
             <a href="#integer">Integer</a>
             <ul>
               <li>
-                <a href="#even"><code><b>even</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#even"><code><b>even</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#odd"><code><b>odd</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#odd"><code><b>odd</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
             </ul>
           </li>
@@ -618,16 +618,16 @@
             <a href="#parse">Parse</a>
             <ul>
               <li>
-                <a href="#parseDate"><code><b>parseDate</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe Date</code></a>
+                <a href="#parseDate"><code><b>parseDate</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe Date</code></a>
               </li>
               <li>
-                <a href="#parseFloat"><code><b>parseFloat</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe Number</code></a>
+                <a href="#parseFloat"><code><b>parseFloat</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe Number</code></a>
               </li>
               <li>
-                <a href="#parseInt"><code><b>parseInt</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe Integer</code></a>
+                <a href="#parseInt"><code><b>parseInt</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe Integer</code></a>
               </li>
               <li>
-                <a href="#parseJson"><code><b>parseJson</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</code></a>
+                <a href="#parseJson"><code><b>parseJson</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</code></a>
               </li>
             </ul>
           </li>
@@ -635,19 +635,19 @@
             <a href="#regexp">RegExp</a>
             <ul>
               <li>
-                <a href="#regex"><code><b>regex</b> <span class="tight">:</span><span class="tight">:</span> RegexFlags <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> RegExp</code></a>
+                <a href="#regex"><code><b>regex</b> <span class="tight">:</span><span class="tight">:</span> RegexFlags <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> RegExp</code></a>
               </li>
               <li>
-                <a href="#regexEscape"><code><b>regexEscape</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#regexEscape"><code><b>regexEscape</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#test"><code><b>test</b> <span class="tight">:</span><span class="tight">:</span> RegExp <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</code></a>
+                <a href="#test"><code><b>test</b> <span class="tight">:</span><span class="tight">:</span> RegExp <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</code></a>
               </li>
               <li>
-                <a href="#match"><code><b>match</b> <span class="tight">:</span><span class="tight">:</span> NonGlobalRegExp <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</code></a>
+                <a href="#match"><code><b>match</b> <span class="tight">:</span><span class="tight">:</span> NonGlobalRegExp <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</code></a>
               </li>
               <li>
-                <a href="#matchAll"><code><b>matchAll</b> <span class="tight">:</span><span class="tight">:</span> GlobalRegExp <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</code></a>
+                <a href="#matchAll"><code><b>matchAll</b> <span class="tight">:</span><span class="tight">:</span> GlobalRegExp <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</code></a>
               </li>
             </ul>
           </li>
@@ -655,28 +655,28 @@
             <a href="#string">String</a>
             <ul>
               <li>
-                <a href="#toUpper"><code><b>toUpper</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#toUpper"><code><b>toUpper</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#toLower"><code><b>toLower</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#toLower"><code><b>toLower</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#trim"><code><b>trim</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#trim"><code><b>trim</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#words"><code><b>words</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String</code></a>
+                <a href="#words"><code><b>words</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String</code></a>
               </li>
               <li>
-                <a href="#unwords"><code><b>unwords</b> <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#unwords"><code><b>unwords</b> <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#lines"><code><b>lines</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String</code></a>
+                <a href="#lines"><code><b>lines</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String</code></a>
               </li>
               <li>
-                <a href="#unlines"><code><b>unlines</b> <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></a>
+                <a href="#unlines"><code><b>unlines</b> <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></a>
               </li>
               <li>
-                <a href="#splitOn"><code><b>splitOn</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String</code></a>
+                <a href="#splitOn"><code><b>splitOn</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String</code></a>
               </li>
             </ul>
           </li>
@@ -725,7 +725,7 @@ to mean &quot;is a member of&quot;, so one could write:</p>
 [1, 2, 3] :: Array Number
 </code></pre><p>An identifier may appear to the left of the double colon:</p>
 <pre><code>Math.PI :: Number
-</code></pre><p>The arrow (<code><span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span></code>) is used to express a function&#39;s type:</p>
+</code></pre><p>The arrow (<code><span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span></code>) is used to express a function&#39;s type:</p>
 <pre><code>Math.abs :: Number -&gt; Number
 </code></pre><p>That states that <code>Math.abs</code> is a unary function which takes an argument
 of type <code>Number</code> and returns a value of type <code>Number</code>.</p>
@@ -743,18 +743,18 @@ The same applies for each other type variable. For the function above, the
 types with which <code>a</code> and <code>b</code> are replaced may be different, but needn&#39;t be.</p>
 <p>Since all Sanctuary functions are curried (they accept their arguments
 one at a time), a binary function is represented as a unary function which
-returns a unary function: <code>* <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> * <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> *</code>. This aligns neatly with Haskell,
+returns a unary function: <code>* <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> * <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> *</code>. This aligns neatly with Haskell,
 which uses curried functions exclusively. In JavaScript, though, we may
 wish to represent the types of functions with arities less than or greater
-than one. The general form is <code>(&lt;input-types&gt;) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> &lt;output-type&gt;</code>, where
+than one. The general form is <code>(&lt;input-types&gt;) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> &lt;output-type&gt;</code>, where
 <code>&lt;input-types&gt;</code> comprises zero or more comma–space (<code>, </code>)
 -separated type representations:</p>
 <ul>
-<li><code>() <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></li>
-<li><code>(a, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></li>
-<li><code>(a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d</code></li>
+<li><code>() <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</code></li>
+<li><code>(a, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code></li>
+<li><code>(a, b, c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d</code></li>
 </ul>
-<p><code>Number <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Number</code> can thus be seen as shorthand for <code>(Number) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Number</code>.</p>
+<p><code>Number <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Number</code> can thus be seen as shorthand for <code>(Number) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Number</code>.</p>
 <p>The question mark (<code>?</code>) is used to represent types which include <code>null</code>
 and <code>undefined</code> as members. <code>String?</code>, for example, represents the type
 comprising <code>null</code>, <code>undefined</code>, and all strings.</p>
@@ -768,15 +768,15 @@ the <code>map</code> method takes an implicit argument <code>x</code> in additio
 argument <code>y</code>. The type of the value upon which a method is invoked appears
 at the beginning of the signature, separated from the arguments and return
 value by a squiggly arrow (<code><span class="arrow">~&gt;</span></code>). The type of the <code>map</code> method of the Maybe
-type is written <code>Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</code>. One could read this as:</p>
+type is written <code>Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</code>. One could read this as:</p>
 <p><em>When the <code>map</code> method is invoked on a value of type <code>Maybe a</code>
-(for any type <code>a</code>) with an argument of type <code>a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code> (for any type <code>b</code>),
+(for any type <code>a</code>) with an argument of type <code>a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</code> (for any type <code>b</code>),
 it returns a value of type <code>Maybe b</code>.</em></p>
 <p>The squiggly arrow is also used when representing non-function properties.
 <code>Maybe a <span class="arrow">~&gt;</span> Boolean</code>, for example, represents a Boolean property of a value
 of type <code>Maybe a</code>.</p>
 <p>Sanctuary supports type classes: constraints on type variables. Whereas
-<code>a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code> implicitly supports every type, <code>Functor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span>
+<code>a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</code> implicitly supports every type, <code>Functor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span>
 f b</code> requires that <code>f</code> be a type which satisfies the requirements of the
 Functor type class. Type-class constraints appear at the beginning of a
 type signature, separated from the rest of the signature by a fat arrow
@@ -797,7 +797,7 @@ Sanctuary&#39;s run-time type checking asserts that a valid Number value is
 provided wherever an Integer value is required.</p>
 <a class="pilcrow h3" href="#type-representatives">¶</a>
 <h3 id="type-representatives">Type representatives</h3>
-<p>What is the type of <code>Number</code>? One answer is <code>a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Number</code>, since it&#39;s a
+<p>What is the type of <code>Number</code>? One answer is <code>a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Number</code>, since it&#39;s a
 function which takes an argument of any type and returns a Number value.
 When provided as the first argument to <a href="#is"><code>is</code></a>, though, <code>Number</code> is
 really the value-level representative of the Number type.</p>
@@ -851,7 +851,7 @@ const S = create({checkTypes: checkTypes, env: env});
 <a class="pilcrow h2" href="#api">¶</a>
 <h2 id="api">API</h2>
 <a class="pilcrow h4" href="#create">¶</a>
-<h4 id="create"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L374">create <span class="tight">:</span><span class="tight">:</span> { checkTypes <span class="tight">:</span><span class="tight">:</span> Boolean, env <span class="tight">:</span><span class="tight">:</span> Array Type } <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Module</a></code></h4>
+<h4 id="create"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L374">create <span class="tight">:</span><span class="tight">:</span> { checkTypes <span class="tight">:</span><span class="tight">:</span> Boolean, env <span class="tight">:</span><span class="tight">:</span> Array Type } <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Module</a></code></h4>
 
 <p>Takes an options record and returns a Sanctuary module. <code>checkTypes</code>
 specifies whether to enable type checking. The module&#39;s polymorphic
@@ -913,7 +913,7 @@ custom environment in conjunction with <a href="#create"><code>create</code></a>
 In many cases one can define a more specific function in terms of
 a more general one simply by applying the more general function to
 some (but not all) of its arguments. For example, one could define
-<code>sum <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f Number <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Number</code> as <code>S.reduce(S.add, 0)</code>.</p>
+<code>sum <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f Number <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Number</code> as <code>S.reduce(S.add, 0)</code>.</p>
 <p>In some cases, though, there are multiple orders in which one may
 wish to provide a function&#39;s arguments. <code>S.concat(&#39;prefix&#39;)</code> is a
 function which prefixes its argument, but how would one define a
@@ -945,7 +945,7 @@ The following are all equivalent (<code>_</code> represents the placeholder):</p
 <a class="pilcrow h3" href="#classify">¶</a>
 <h3 id="classify">Classify</h3>
 <a class="pilcrow h4" href="#type">¶</a>
-<h4 id="type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L481">type <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L481">type <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Returns the <a href="https://github.com/sanctuary-js/sanctuary-type-identifiers/tree/v1.0.0">type identifier</a> of the given value.</p>
 <div class="examples">
@@ -960,7 +960,7 @@ The following are all equivalent (<code>_</code> represents the placeholder):</p
 </div>
 
 <a class="pilcrow h4" href="#is">¶</a>
-<h4 id="is"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L494">is <span class="tight">:</span><span class="tight">:</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="is"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L494">is <span class="tight">:</span><span class="tight">:</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Any <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Takes a <a href="#type-representatives">type representative</a> and a value of
 any type and returns <code>true</code> if the given value is of the specified
@@ -983,7 +983,7 @@ type; <code>false</code> otherwise. Subtyping is not respected.</p>
 <a class="pilcrow h3" href="#showable">¶</a>
 <h3 id="showable">Showable</h3>
 <a class="pilcrow h4" href="#toString">¶</a>
-<h4 id="toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L523">toString <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L523">toString <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Alias of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#toString"><code>Z.toString</code></a>.</p>
 <div class="examples">
@@ -1009,7 +1009,7 @@ type; <code>false</code> otherwise. Subtyping is not respected.</p>
 <h3 id="fantasy-land">Fantasy Land</h3>
 <p>Sanctuary is compatible with the <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0">Fantasy Land</a> specification.</p>
 <a class="pilcrow h4" href="#equals">¶</a>
-<h4 id="equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L546">equals <span class="tight">:</span><span class="tight">:</span> Setoid a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L546">equals <span class="tight">:</span><span class="tight">:</span> Setoid a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#equals"><code>Z.equals</code></a> which requires two arguments of the
 same type.</p>
@@ -1032,7 +1032,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#concat">¶</a>
-<h4 id="concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L567">concat <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</a></code></h4>
+<h4 id="concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L567">concat <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#concat"><code>Z.concat</code></a>.</p>
 <div class="examples">
@@ -1055,7 +1055,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#empty">¶</a>
-<h4 id="empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L586">empty <span class="tight">:</span><span class="tight">:</span> Monoid a <span class="arrow">=&gt;</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</a></code></h4>
+<h4 id="empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L586">empty <span class="tight">:</span><span class="tight">:</span> Monoid a <span class="arrow">=&gt;</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</a></code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#empty"><code>Z.empty</code></a>.</p>
 <div class="examples">
@@ -1074,7 +1074,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#map">¶</a>
-<h4 id="map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L602">map <span class="tight">:</span><span class="tight">:</span> Functor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b</a></code></h4>
+<h4 id="map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L602">map <span class="tight">:</span><span class="tight">:</span> Functor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#map"><code>Z.map</code></a>.</p>
 <div class="examples">
@@ -1112,7 +1112,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#bimap">¶</a>
-<h4 id="bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L636">bimap <span class="tight">:</span><span class="tight">:</span> Bifunctor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b d</a></code></h4>
+<h4 id="bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L636">bimap <span class="tight">:</span><span class="tight">:</span> Bifunctor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b d</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#bimap"><code>Z.bimap</code></a>.</p>
 <div class="examples">
@@ -1127,7 +1127,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#promap">¶</a>
-<h4 id="promap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L653">promap <span class="tight">:</span><span class="tight">:</span> Profunctor p <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> p b c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> p a d</a></code></h4>
+<h4 id="promap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L653">promap <span class="tight">:</span><span class="tight">:</span> Profunctor p <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> p b c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> p a d</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#promap"><code>Z.promap</code></a>.</p>
 <div class="examples">
@@ -1138,7 +1138,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#alt">¶</a>
-<h4 id="alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L667">alt <span class="tight">:</span><span class="tight">:</span> Alt f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a</a></code></h4>
+<h4 id="alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L667">alt <span class="tight">:</span><span class="tight">:</span> Alt f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#alt"><code>Z.alt</code></a>.</p>
 <div class="examples">
@@ -1161,7 +1161,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#zero">¶</a>
-<h4 id="zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L686">zero <span class="tight">:</span><span class="tight">:</span> Plus f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a</a></code></h4>
+<h4 id="zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L686">zero <span class="tight">:</span><span class="tight">:</span> Plus f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a</a></code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#zero"><code>Z.zero</code></a>.</p>
 <div class="examples">
@@ -1180,7 +1180,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#reduce">¶</a>
-<h4 id="reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L703">reduce <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L703">reduce <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>Takes a curried binary function, an initial value, and a <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#foldable">Foldable</a>,
 and applies the function to the initial value and the Foldable&#39;s first
@@ -1202,11 +1202,11 @@ otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#reduce_">¶</a>
-<h4 id="reduce_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L728">reduce_ <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="reduce_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L728">reduce_ <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>Variant of <a href="#reduce"><code>reduce</code></a> which takes an uncurried binary function.</p>
 <a class="pilcrow h4" href="#traverse">¶</a>
-<h4 id="traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L737">traverse <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> t a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f (t b)</a></code></h4>
+<h4 id="traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L737">traverse <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> t a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f (t b)</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#traverse"><code>Z.traverse</code></a>.</p>
 <div class="examples">
@@ -1229,7 +1229,7 @@ otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sequence">¶</a>
-<h4 id="sequence"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L760">sequence <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> t (f a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f (t a)</a></code></h4>
+<h4 id="sequence"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L760">sequence <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> t (f a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f (t a)</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#sequence"><code>Z.sequence</code></a>.</p>
 <div class="examples">
@@ -1248,7 +1248,7 @@ otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#ap">¶</a>
-<h4 id="ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L780">ap <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b</a></code></h4>
+<h4 id="ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L780">ap <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#ap"><code>Z.ap</code></a>.</p>
 <div class="examples">
@@ -1278,7 +1278,7 @@ Function a (b -&gt; c) -&gt; Function a b -&gt; Function a c
 </div>
 
 <a class="pilcrow h4" href="#lift2">¶</a>
-<h4 id="lift2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L812">lift2 <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f c</a></code></h4>
+<h4 id="lift2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L812">lift2 <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f c</a></code></h4>
 
 <p>Promotes a curried binary function to a function which operates on two
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#apply">Apply</a>s.</p>
@@ -1302,7 +1302,7 @@ Function a (b -&gt; c) -&gt; Function a b -&gt; Function a c
 </div>
 
 <a class="pilcrow h4" href="#lift3">¶</a>
-<h4 id="lift3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L833">lift3 <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f d</a></code></h4>
+<h4 id="lift3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L833">lift3 <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f d</a></code></h4>
 
 <p>Promotes a curried ternary function to a function which operates on three
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#apply">Apply</a>s.</p>
@@ -1318,7 +1318,7 @@ Function a (b -&gt; c) -&gt; Function a b -&gt; Function a c
 </div>
 
 <a class="pilcrow h4" href="#apFirst">¶</a>
-<h4 id="apFirst"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L851">apFirst <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a</a></code></h4>
+<h4 id="apFirst"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L851">apFirst <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#apFirst"><code>Z.apFirst</code></a>. Combines two effectful actions,
 keeping only the result of the first. Equivalent to Haskell&#39;s <code>(&lt;*)</code>
@@ -1336,7 +1336,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#apSecond">¶</a>
-<h4 id="apSecond"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L868">apSecond <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b</a></code></h4>
+<h4 id="apSecond"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L868">apSecond <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#apSecond"><code>Z.apSecond</code></a>. Combines two effectful actions,
 keeping only the result of the second. Equivalent to Haskell&#39;s <code>(*&gt;)</code>
@@ -1354,7 +1354,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#of">¶</a>
-<h4 id="of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L885">of <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a</a></code></h4>
+<h4 id="of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L885">of <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#of"><code>Z.of</code></a>.</p>
 <div class="examples">
@@ -1377,7 +1377,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#chain">¶</a>
-<h4 id="chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L908">chain <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m b</a></code></h4>
+<h4 id="chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L908">chain <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m b</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#chain"><code>Z.chain</code></a>.</p>
 <div class="examples">
@@ -1400,7 +1400,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#join">¶</a>
-<h4 id="join"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L927">join <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> m (m a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m a</a></code></h4>
+<h4 id="join"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L927">join <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> m (m a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m a</a></code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#join"><code>Z.join</code></a>.
 Removes one level of nesting from a nested monadic structure.</p>
@@ -1432,7 +1432,7 @@ Function x (Function x a) -&gt; Function x a
 </div>
 
 <a class="pilcrow h4" href="#chainRec">¶</a>
-<h4 id="chainRec"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L956">chainRec <span class="tight">:</span><span class="tight">:</span> ChainRec m <span class="arrow">=&gt;</span> TypeRep m <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m (Either a b)) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m b</a></code></h4>
+<h4 id="chainRec"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L956">chainRec <span class="tight">:</span><span class="tight">:</span> ChainRec m <span class="arrow">=&gt;</span> TypeRep m <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m (Either a b)) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m b</a></code></h4>
 
 <p>Performs a <a href="#chain"><code>chain</code></a>-like computation with constant stack usage.
 Similar to <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#chainRec"><code>Z.chainRec</code></a>, but curried and more convenient due to the
@@ -1445,7 +1445,7 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#extend">¶</a>
-<h4 id="extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L981">extend <span class="tight">:</span><span class="tight">:</span> Extend w <span class="arrow">=&gt;</span> (w a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> w b</a></code></h4>
+<h4 id="extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L981">extend <span class="tight">:</span><span class="tight">:</span> Extend w <span class="arrow">=&gt;</span> (w a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> w b</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#extend"><code>Z.extend</code></a>.</p>
 <div class="examples">
@@ -1456,11 +1456,11 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#extract">¶</a>
-<h4 id="extract"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L992">extract <span class="tight">:</span><span class="tight">:</span> Comonad w <span class="arrow">=&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</a></code></h4>
+<h4 id="extract"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L992">extract <span class="tight">:</span><span class="tight">:</span> Comonad w <span class="arrow">=&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</a></code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#extract"><code>Z.extract</code></a>.</p>
 <a class="pilcrow h4" href="#filter">¶</a>
-<h4 id="filter"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L998">filter <span class="tight">:</span><span class="tight">:</span> (Applicative f, Foldable f, Monoid (f a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a</a></code></h4>
+<h4 id="filter"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L998">filter <span class="tight">:</span><span class="tight">:</span> (Applicative f, Foldable f, Monoid (f a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f a</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#filter"><code>Z.filter</code></a>.</p>
 <p>See also <a href="#filterM"><code>filterM</code></a>.</p>
@@ -1480,7 +1480,7 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#filterM">¶</a>
-<h4 id="filterM"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1020">filterM <span class="tight">:</span><span class="tight">:</span> (Monad m, Monoid (m a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> m a</a></code></h4>
+<h4 id="filterM"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1020">filterM <span class="tight">:</span><span class="tight">:</span> (Monad m, Monoid (m a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> m a</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#filterM"><code>Z.filterM</code></a>.</p>
 <p>See also <a href="#filter"><code>filter</code></a>.</p>
@@ -1502,7 +1502,7 @@ use of the Either type to indicate completion (via a Right).</p>
 <a class="pilcrow h3" href="#combinator">¶</a>
 <h3 id="combinator">Combinator</h3>
 <a class="pilcrow h4" href="#I">¶</a>
-<h4 id="I"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1044">I <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</a></code></h4>
+<h4 id="I"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1044">I <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</a></code></h4>
 
 <p>The I combinator. Returns its argument. Equivalent to Haskell&#39;s <code>id</code>
 function.</p>
@@ -1514,7 +1514,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#K">¶</a>
-<h4 id="K"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1058">K <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</a></code></h4>
+<h4 id="K"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1058">K <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</a></code></h4>
 
 <p>The K combinator. Takes two values and returns the first. Equivalent to
 Haskell&#39;s <code>const</code> function.</p>
@@ -1530,7 +1530,7 @@ Haskell&#39;s <code>const</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#A">¶</a>
-<h4 id="A"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1075">A <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="A"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1075">A <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>The A combinator. Takes a function and a value, and returns the result
 of applying the function to the value. Equivalent to Haskell&#39;s <code>($)</code>
@@ -1547,7 +1547,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#T">¶</a>
-<h4 id="T"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1093">T <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="T"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1093">T <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>The T (<a href="https://github.com/raganwald-deprecated/homoiconic/blob/master/2008-10-30/thrush.markdown">thrush</a>) combinator. Takes a value and a function, and returns
 the result of applying the function to the value. Equivalent to Haskell&#39;s
@@ -1566,7 +1566,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 <a class="pilcrow h3" href="#function">¶</a>
 <h3 id="function">Function</h3>
 <a class="pilcrow h4" href="#curry2">¶</a>
-<h4 id="curry2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1113">curry2 <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</a></code></h4>
+<h4 id="curry2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1113">curry2 <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</a></code></h4>
 
 <p>Curries the given binary function.</p>
 <div class="examples">
@@ -1581,7 +1581,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#curry3">¶</a>
-<h4 id="curry3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1133">curry3 <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d</a></code></h4>
+<h4 id="curry3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1133">curry3 <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d</a></code></h4>
 
 <p>Curries the given ternary function.</p>
 <div class="examples">
@@ -1600,7 +1600,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#curry4">¶</a>
-<h4 id="curry4"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1158">curry4 <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> e) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> e</a></code></h4>
+<h4 id="curry4"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1158">curry4 <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> e) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> e</a></code></h4>
 
 <p>Curries the given quaternary function.</p>
 <div class="examples">
@@ -1619,7 +1619,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#curry5">¶</a>
-<h4 id="curry5"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1183">curry5 <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d, e) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> e <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f</a></code></h4>
+<h4 id="curry5"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1183">curry5 <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d, e) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> e <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f</a></code></h4>
 
 <p>Curries the given quinary function.</p>
 <div class="examples">
@@ -1638,7 +1638,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#flip">¶</a>
-<h4 id="flip"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1212">flip <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</a></code></h4>
+<h4 id="flip"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1212">flip <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</a></code></h4>
 
 <p>Takes a curried binary function and two values, and returns the
 result of applying the function to the values in reverse order.</p>
@@ -1651,13 +1651,13 @@ result of applying the function to the values in reverse order.</p>
 </div>
 
 <a class="pilcrow h4" href="#flip_">¶</a>
-<h4 id="flip_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1228">flip_ <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</a></code></h4>
+<h4 id="flip_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1228">flip_ <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</a></code></h4>
 
 <p>Variant of <a href="#flip"><code>flip</code></a> which takes an uncurried binary function.</p>
 <a class="pilcrow h3" href="#composition">¶</a>
 <h3 id="composition">Composition</h3>
 <a class="pilcrow h4" href="#compose">¶</a>
-<h4 id="compose"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1238">compose <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</a></code></h4>
+<h4 id="compose"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1238">compose <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</a></code></h4>
 
 <p>Composes two unary functions, from right to left. Equivalent to Haskell&#39;s
 <code>(.)</code> function.</p>
@@ -1671,7 +1671,7 @@ result of applying the function to the values in reverse order.</p>
 </div>
 
 <a class="pilcrow h4" href="#pipe">¶</a>
-<h4 id="pipe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1256">pipe <span class="tight">:</span><span class="tight">:</span> [(a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b), (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c), <span class="tight">.</span><span class="tight">.</span><span class="tight">.</span>, (m <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> n)] <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> n</a></code></h4>
+<h4 id="pipe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1256">pipe <span class="tight">:</span><span class="tight">:</span> [(a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b), (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c), <span class="tight">.</span><span class="tight">.</span><span class="tight">.</span>, (m <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> n)] <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> n</a></code></h4>
 
 <p>Takes an array of functions assumed to be unary and a value of any type,
 and returns the result of applying the sequence of transformations to
@@ -1686,7 +1686,7 @@ of functions. <code>pipe([f, g, h], x)</code> is equivalent to <code>h(g(f(x)))<
 </div>
 
 <a class="pilcrow h4" href="#on">¶</a>
-<h4 id="on"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1274">on <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</a></code></h4>
+<h4 id="on"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1274">on <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</a></code></h4>
 
 <p>Takes a binary function <code>f</code>, a unary function <code>g</code>, and two
 values <code>x</code> and <code>y</code>. Returns <code>f(g(x))(g(y))</code>.</p>
@@ -1699,7 +1699,7 @@ values <code>x</code> and <code>y</code>. Returns <code>f(g(x))(g(y))</code>.</p
 </div>
 
 <a class="pilcrow h4" href="#on_">¶</a>
-<h4 id="on_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1290">on_ <span class="tight">:</span><span class="tight">:</span> ((b, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</a></code></h4>
+<h4 id="on_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1290">on_ <span class="tight">:</span><span class="tight">:</span> ((b, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</a></code></h4>
 
 <p>Variant of <a href="#on"><code>on</code></a> which takes an uncurried binary function.</p>
 <a class="pilcrow h3" href="#maybe-type">¶</a>
@@ -1709,7 +1709,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 <p>The Maybe type satisfies the <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#setoid">Setoid</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#monoid">Monoid</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#monad">Monad</a>,
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#alternative">Alternative</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#traversable">Traversable</a>, and <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#extend">Extend</a> specifications.</p>
 <a class="pilcrow h4" href="#MaybeType">¶</a>
-<h4 id="MaybeType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1306">MaybeType <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Type</a></code></h4>
+<h4 id="MaybeType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1306">MaybeType <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Type</a></code></h4>
 
 <p>A <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0#UnaryType"><code>UnaryType</code></a> for use with <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0">sanctuary-def</a>.</p>
 <a class="pilcrow h4" href="#Maybe">¶</a>
@@ -1728,7 +1728,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Just">¶</a>
-<h4 id="Just"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1334">Just <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="Just"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1334">Just <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Takes a value of any type and returns a Just with the given value.</p>
 <div class="examples">
@@ -1743,7 +1743,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 
 <p>Maybe type identifier, <code>&#39;sanctuary/Maybe&#39;</code>.</p>
 <a class="pilcrow h4" href="#Maybe.fantasy-land/empty">¶</a>
-<h4 id="Maybe.fantasy-land/empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1352">Maybe.fantasy-land/empty <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="Maybe.fantasy-land/empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1352">Maybe.fantasy-land/empty <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Returns Nothing.</p>
 <div class="examples">
@@ -1754,7 +1754,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.fantasy-land/of">¶</a>
-<h4 id="Maybe.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1362">Maybe.fantasy-land/of <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="Maybe.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1362">Maybe.fantasy-land/of <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Takes a value of any type and returns a Just with the given value.</p>
 <div class="examples">
@@ -1765,7 +1765,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.fantasy-land/zero">¶</a>
-<h4 id="Maybe.fantasy-land/zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1372">Maybe.fantasy-land/zero <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="Maybe.fantasy-land/zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1372">Maybe.fantasy-land/zero <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Returns Nothing.</p>
 <div class="examples">
@@ -1806,7 +1806,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.toString">¶</a>
-<h4 id="Maybe.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1406">Maybe#toString <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="Maybe.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1406">Maybe#toString <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Returns the string representation of the Maybe.</p>
 <div class="examples">
@@ -1821,7 +1821,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.inspect">¶</a>
-<h4 id="Maybe.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1421">Maybe#inspect <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="Maybe.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1421">Maybe#inspect <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Returns the string representation of the Maybe. This method is used by
 <code>util.inspect</code> and the REPL to format a Maybe for display.</p>
@@ -1838,7 +1838,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/equals">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1437">Maybe#fantasy-land/equals <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1437">Maybe#fantasy-land/equals <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Takes a value of the same type and returns <code>true</code> if:</p>
 <ul>
@@ -1868,7 +1868,7 @@ according to <a href="#equals"><code>equals</code></a>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/concat">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1464">Maybe#fantasy-land/concat <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1464">Maybe#fantasy-land/concat <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Returns the result of concatenating two Maybe values of the same type.
 <code>a</code> must have a <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#semigroup">Semigroup</a>.</p>
@@ -1898,7 +1898,7 @@ the given Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/map">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1497">Maybe#fantasy-land/map <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1497">Maybe#fantasy-land/map <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</a></code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is Nothing; otherwise
 it returns a Just whose value is the result of applying the function
@@ -1915,7 +1915,7 @@ to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/ap">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1514">Maybe#fantasy-land/ap <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1514">Maybe#fantasy-land/ap <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</a></code></h4>
 
 <p>Takes a Maybe and returns Nothing unless <code>this</code> is a Just <em>and</em> the
 argument is a Just, in which case it returns a Just whose value is
@@ -1940,7 +1940,7 @@ the result of applying the given Just&#39;s value to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/chain">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1537">Maybe#fantasy-land/chain <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1537">Maybe#fantasy-land/chain <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</a></code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is Nothing; otherwise
 it returns the result of applying the function to this Just&#39;s value.</p>
@@ -1960,7 +1960,7 @@ it returns the result of applying the function to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/alt">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1556">Maybe#fantasy-land/alt <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1556">Maybe#fantasy-land/alt <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Chooses between <code>this</code> and the other Maybe provided as an argument.
 Returns <code>this</code> if <code>this</code> is a Just; the other Maybe otherwise.</p>
@@ -1984,7 +1984,7 @@ Returns <code>this</code> if <code>this</code> is a Just; the other Maybe otherw
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/reduce">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1578">Maybe#fantasy-land/reduce <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1578">Maybe#fantasy-land/reduce <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>Takes a function and an initial value of any type, and returns:</p>
 <ul>
@@ -2006,7 +2006,7 @@ Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/traverse">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1598">Maybe#fantasy-land/traverse <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> (TypeRep f, a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f (Maybe b)</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1598">Maybe#fantasy-land/traverse <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> (TypeRep f, a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f (Maybe b)</a></code></h4>
 
 <p>Takes two functions which both return values of the same <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#applicative">Applicative</a>,
 (the second of which must be that type&#39;s <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#of-method"><code>of</code></a> function) and returns:</p>
@@ -2029,7 +2029,7 @@ first function to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/extend">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1619">Maybe#fantasy-land/extend <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1619">Maybe#fantasy-land/extend <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</a></code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is Nothing; otherwise
 it returns a Just whose value is the result of applying the function
@@ -2046,7 +2046,7 @@ to <code>this</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#isNothing">¶</a>
-<h4 id="isNothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1636">isNothing <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="isNothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1636">isNothing <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Maybe is Nothing; <code>false</code> if it is a Just.</p>
 <div class="examples">
@@ -2061,7 +2061,7 @@ to <code>this</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#isJust">¶</a>
-<h4 id="isJust"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1652">isJust <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="isJust"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1652">isJust <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Maybe is a Just; <code>false</code> if it is Nothing.</p>
 <div class="examples">
@@ -2076,7 +2076,7 @@ to <code>this</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#fromMaybe">¶</a>
-<h4 id="fromMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1668">fromMaybe <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</a></code></h4>
+<h4 id="fromMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1668">fromMaybe <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</a></code></h4>
 
 <p>Takes a default value and a Maybe, and returns the Maybe&#39;s value
 if the Maybe is a Just; the default value otherwise.</p>
@@ -2094,7 +2094,7 @@ if the Maybe is a Just; the default value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#fromMaybe_">¶</a>
-<h4 id="fromMaybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1688">fromMaybe_ <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</a></code></h4>
+<h4 id="fromMaybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1688">fromMaybe_ <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</a></code></h4>
 
 <p>Variant of <a href="#fromMaybe"><code>fromMaybe</code></a> which takes a thunk so the default
 value is only computed if required.</p>
@@ -2114,7 +2114,7 @@ value is only computed if required.</p>
 </div>
 
 <a class="pilcrow h4" href="#maybeToNullable">¶</a>
-<h4 id="maybeToNullable"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1707">maybeToNullable <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Nullable a</a></code></h4>
+<h4 id="maybeToNullable"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1707">maybeToNullable <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Nullable a</a></code></h4>
 
 <p>Returns the given Maybe&#39;s value if the Maybe is a Just; <code>null</code> otherwise.
 <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0#Nullable">Nullable</a> is defined in <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0">sanctuary-def</a>.</p>
@@ -2131,7 +2131,7 @@ value is only computed if required.</p>
 </div>
 
 <a class="pilcrow h4" href="#toMaybe">¶</a>
-<h4 id="toMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1727">toMaybe <span class="tight">:</span><span class="tight">:</span> a? <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="toMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1727">toMaybe <span class="tight">:</span><span class="tight">:</span> a? <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Takes a value and returns Nothing if the value is <code>null</code> or <code>undefined</code>;
 Just the value otherwise.</p>
@@ -2147,7 +2147,7 @@ Just the value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#maybe">¶</a>
-<h4 id="maybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1744">maybe <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="maybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1744">maybe <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>Takes a value of any type, a function, and a Maybe. If the Maybe is
 a Just, the return value is the result of applying the function to
@@ -2165,7 +2165,7 @@ the Just&#39;s value. Otherwise, the first argument is returned.</p>
 </div>
 
 <a class="pilcrow h4" href="#maybe_">¶</a>
-<h4 id="maybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1764">maybe_ <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="maybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1764">maybe_ <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>Variant of <a href="#maybe"><code>maybe</code></a> which takes a thunk so the default value
 is only computed if required.</p>
@@ -2185,7 +2185,7 @@ is only computed if required.</p>
 </div>
 
 <a class="pilcrow h4" href="#justs">¶</a>
-<h4 id="justs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1783">justs <span class="tight">:</span><span class="tight">:</span> Array (Maybe a) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</a></code></h4>
+<h4 id="justs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1783">justs <span class="tight">:</span><span class="tight">:</span> Array (Maybe a) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</a></code></h4>
 
 <p>Takes an array of Maybes and returns an array containing each Just&#39;s
 value. Equivalent to Haskell&#39;s <code>catMaybes</code> function.</p>
@@ -2198,7 +2198,7 @@ value. Equivalent to Haskell&#39;s <code>catMaybes</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#mapMaybe">¶</a>
-<h4 id="mapMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1802">mapMaybe <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array b</a></code></h4>
+<h4 id="mapMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1802">mapMaybe <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array b</a></code></h4>
 
 <p>Takes a function and an array, applies the function to each element of
 the array, and returns an array of &quot;successful&quot; results. If the result of
@@ -2214,7 +2214,7 @@ the output array.</p>
 </div>
 
 <a class="pilcrow h4" href="#encase">¶</a>
-<h4 id="encase"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1822">encase <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</a></code></h4>
+<h4 id="encase"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1822">encase <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</a></code></h4>
 
 <p>Takes a unary function <code>f</code> which may throw and a value <code>x</code> of any type,
 and applies <code>f</code> to <code>x</code> inside a <code>try</code> block. If an exception is caught,
@@ -2233,27 +2233,27 @@ result of applying <code>f</code> to <code>x</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#encase2">¶</a>
-<h4 id="encase2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1847">encase2 <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe c</a></code></h4>
+<h4 id="encase2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1847">encase2 <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe c</a></code></h4>
 
 <p>Binary version of <a href="#encase"><code>encase</code></a>.</p>
 <p>See also <a href="#encase2_"><code>encase2_</code></a>.</p>
 <a class="pilcrow h4" href="#encase2_">¶</a>
-<h4 id="encase2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1857">encase2_ <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe c</a></code></h4>
+<h4 id="encase2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1857">encase2_ <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe c</a></code></h4>
 
 <p>Variant of <a href="#encase2"><code>encase2</code></a> which takes an uncurried binary
 function.</p>
 <a class="pilcrow h4" href="#encase3">¶</a>
-<h4 id="encase3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1871">encase3 <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe d</a></code></h4>
+<h4 id="encase3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1871">encase3 <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe d</a></code></h4>
 
 <p>Ternary version of <a href="#encase"><code>encase</code></a>.</p>
 <p>See also <a href="#encase3_"><code>encase3_</code></a>.</p>
 <a class="pilcrow h4" href="#encase3_">¶</a>
-<h4 id="encase3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1882">encase3_ <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe d</a></code></h4>
+<h4 id="encase3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1882">encase3_ <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe d</a></code></h4>
 
 <p>Variant of <a href="#encase3"><code>encase3</code></a> which takes an uncurried ternary
 function.</p>
 <a class="pilcrow h4" href="#maybeToEither">¶</a>
-<h4 id="maybeToEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1899">maybeToEither <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</a></code></h4>
+<h4 id="maybeToEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1899">maybeToEither <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</a></code></h4>
 
 <p>Converts a Maybe to an Either. Nothing becomes a Left (containing the
 first argument); a Just becomes a Right.</p>
@@ -2277,7 +2277,7 @@ value is of type <code>b</code>.</p>
 <p>The Either type satisfies the <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#setoid">Setoid</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#semigroup">Semigroup</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#monad">Monad</a>,
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#alt">Alt</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#traversable">Traversable</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#extend">Extend</a>, and <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#bifunctor">Bifunctor</a> specifications.</p>
 <a class="pilcrow h4" href="#EitherType">¶</a>
-<h4 id="EitherType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1928">EitherType <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Type</a></code></h4>
+<h4 id="EitherType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1928">EitherType <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Type <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Type</a></code></h4>
 
 <p>A <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0#BinaryType"><code>BinaryType</code></a> for use with <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0">sanctuary-def</a>.</p>
 <a class="pilcrow h4" href="#Either">¶</a>
@@ -2285,7 +2285,7 @@ value is of type <code>b</code>.</p>
 
 <p>The <a href="#type-representatives">type representative</a> for the Either type.</p>
 <a class="pilcrow h4" href="#Left">¶</a>
-<h4 id="Left"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1946">Left <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</a></code></h4>
+<h4 id="Left"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1946">Left <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</a></code></h4>
 
 <p>Takes a value of any type and returns a Left with the given value.</p>
 <div class="examples">
@@ -2296,7 +2296,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Right">¶</a>
-<h4 id="Right"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1959">Right <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</a></code></h4>
+<h4 id="Right"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1959">Right <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</a></code></h4>
 
 <p>Takes a value of any type and returns a Right with the given value.</p>
 <div class="examples">
@@ -2311,7 +2311,7 @@ value is of type <code>b</code>.</p>
 
 <p>Either type identifier, <code>&#39;sanctuary/Either&#39;</code>.</p>
 <a class="pilcrow h4" href="#Either.fantasy-land/of">¶</a>
-<h4 id="Either.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1977">Either.fantasy-land/of <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</a></code></h4>
+<h4 id="Either.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L1977">Either.fantasy-land/of <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</a></code></h4>
 
 <p>Takes a value of any type and returns a Right with the given value.</p>
 <div class="examples">
@@ -2352,7 +2352,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.toString">¶</a>
-<h4 id="Either.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2011">Either#toString <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="Either.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2011">Either#toString <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Returns the string representation of the Either.</p>
 <div class="examples">
@@ -2367,7 +2367,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.inspect">¶</a>
-<h4 id="Either.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2027">Either#inspect <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="Either.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2027">Either#inspect <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Returns the string representation of the Either. This method is used by
 <code>util.inspect</code> and the REPL to format a Either for display.</p>
@@ -2384,7 +2384,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/equals">¶</a>
-<h4 id="Either.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2043">Either#fantasy-land/equals <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2043">Either#fantasy-land/equals <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Takes a value of the same type and returns <code>true</code> if:</p>
 <ul>
@@ -2407,7 +2407,7 @@ according to <a href="#equals"><code>equals</code></a>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/concat">¶</a>
-<h4 id="Either.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2064">Either#fantasy-land/concat <span class="tight">:</span><span class="tight">:</span> (Semigroup a, Semigroup b) <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2064">Either#fantasy-land/concat <span class="tight">:</span><span class="tight">:</span> (Semigroup a, Semigroup b) <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</a></code></h4>
 
 <p>Returns the result of concatenating two Either values of the same type.
 <code>a</code> must have a <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#semigroup">Semigroup</a>, as must <code>b</code>.</p>
@@ -2438,7 +2438,7 @@ the given Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/map">¶</a>
-<h4 id="Either.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2098">Either#fantasy-land/map <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a c</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2098">Either#fantasy-land/map <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a c</a></code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is a Left; otherwise it
 returns a Right whose value is the result of applying the function to
@@ -2456,7 +2456,7 @@ this Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/bimap">¶</a>
-<h4 id="Either.prototype.fantasy-land/bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2117">Either#fantasy-land/bimap <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c, b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either c d</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2117">Either#fantasy-land/bimap <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c, b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either c d</a></code></h4>
 
 <p>Takes two functions and returns:</p>
 <ul>
@@ -2481,7 +2481,7 @@ left side as well as the right side.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/ap">¶</a>
-<h4 id="Either.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2141">Either#fantasy-land/ap <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a c</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2141">Either#fantasy-land/ap <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a c</a></code></h4>
 
 <p>Takes an Either and returns a Left unless <code>this</code> is a Right <em>and</em> the
 argument is a Right, in which case it returns a Right whose value is
@@ -2506,7 +2506,7 @@ the result of applying the given Right&#39;s value to this Right&#39;s value.</p
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/chain">¶</a>
-<h4 id="Either.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2164">Either#fantasy-land/chain <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a c</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2164">Either#fantasy-land/chain <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a c</a></code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is a Left; otherwise
 it returns the result of applying the function to this Right&#39;s value.</p>
@@ -2530,7 +2530,7 @@ it returns the result of applying the function to this Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/alt">¶</a>
-<h4 id="Either.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2188">Either#fantasy-land/alt <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2188">Either#fantasy-land/alt <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</a></code></h4>
 
 <p>Chooses between <code>this</code> and the other Either provided as an argument.
 Returns <code>this</code> if <code>this</code> is a Right; the other Either otherwise.</p>
@@ -2554,7 +2554,7 @@ Returns <code>this</code> if <code>this</code> is a Right; the other Either othe
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/reduce">¶</a>
-<h4 id="Either.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2210">Either#fantasy-land/reduce <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> ((c, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c, c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2210">Either#fantasy-land/reduce <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> ((c, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c, c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</a></code></h4>
 
 <p>Takes a function and an initial value of any type, and returns:</p>
 <ul>
@@ -2576,7 +2576,7 @@ Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/traverse">¶</a>
-<h4 id="Either.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2230">Either#fantasy-land/traverse <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> (TypeRep f, b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f (Either a c)</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2230">Either#fantasy-land/traverse <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> (TypeRep f, b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> f (Either a c)</a></code></h4>
 
 <p>Takes two functions which both return values of the same <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#applicative">Applicative</a>,
 (the second of which must be that type&#39;s <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#of-method"><code>of</code></a> function) and returns:</p>
@@ -2599,7 +2599,7 @@ the first function to this Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/extend">¶</a>
-<h4 id="Either.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2251">Either#fantasy-land/extend <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a c</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2251">Either#fantasy-land/extend <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a c</a></code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is a Left; otherwise it
 returns a Right whose value is the result of applying the function to
@@ -2616,7 +2616,7 @@ returns a Right whose value is the result of applying the function to
 </div>
 
 <a class="pilcrow h4" href="#isLeft">¶</a>
-<h4 id="isLeft"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2268">isLeft <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="isLeft"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2268">isLeft <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Either is a Left; <code>false</code> if it is a Right.</p>
 <div class="examples">
@@ -2631,7 +2631,7 @@ returns a Right whose value is the result of applying the function to
 </div>
 
 <a class="pilcrow h4" href="#isRight">¶</a>
-<h4 id="isRight"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2284">isRight <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="isRight"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2284">isRight <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Either is a Right; <code>false</code> if it is a Left.</p>
 <div class="examples">
@@ -2646,7 +2646,7 @@ returns a Right whose value is the result of applying the function to
 </div>
 
 <a class="pilcrow h4" href="#fromEither">¶</a>
-<h4 id="fromEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2300">fromEither <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="fromEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2300">fromEither <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>Takes a default value and an Either, and returns the Right value
 if the Either is a Right; the default value otherwise.</p>
@@ -2662,7 +2662,7 @@ if the Either is a Right; the default value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#toEither">¶</a>
-<h4 id="toEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2317">toEither <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b? <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b</a></code></h4>
+<h4 id="toEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2317">toEither <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b? <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b</a></code></h4>
 
 <p>Converts an arbitrary value to an Either: a Left if the value is <code>null</code>
 or <code>undefined</code>; a Right otherwise. The first argument specifies the
@@ -2687,7 +2687,7 @@ value of the Left in the &quot;failure&quot; case.</p>
 </div>
 
 <a class="pilcrow h4" href="#either">¶</a>
-<h4 id="either"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2341">either <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c</a></code></h4>
+<h4 id="either"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2341">either <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c</a></code></h4>
 
 <p>Takes two functions and an Either, and returns the result of
 applying the first function to the Left&#39;s value, if the Either
@@ -2705,7 +2705,7 @@ Right&#39;s value, if the Either is a Right.</p>
 </div>
 
 <a class="pilcrow h4" href="#lefts">¶</a>
-<h4 id="lefts"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2360">lefts <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</a></code></h4>
+<h4 id="lefts"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2360">lefts <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</a></code></h4>
 
 <p>Takes an array of Eithers and returns an array containing each Left&#39;s
 value.</p>
@@ -2718,7 +2718,7 @@ value.</p>
 </div>
 
 <a class="pilcrow h4" href="#rights">¶</a>
-<h4 id="rights"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2379">rights <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array b</a></code></h4>
+<h4 id="rights"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2379">rights <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array b</a></code></h4>
 
 <p>Takes an array of Eithers and returns an array containing each Right&#39;s
 value.</p>
@@ -2731,7 +2731,7 @@ value.</p>
 </div>
 
 <a class="pilcrow h4" href="#encaseEither">¶</a>
-<h4 id="encaseEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2398">encaseEither <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either l r</a></code></h4>
+<h4 id="encaseEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2398">encaseEither <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either l r</a></code></h4>
 
 <p>Takes two unary functions, <code>f</code> and <code>g</code>, the second of which may throw,
 and a value <code>x</code> of any type. Applies <code>g</code> to <code>x</code> inside a <code>try</code> block.
@@ -2755,27 +2755,27 @@ value is a Right containing the result of applying <code>g</code> to <code>x</co
 </div>
 
 <a class="pilcrow h4" href="#encaseEither2">¶</a>
-<h4 id="encaseEither2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2431">encaseEither2 <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either l r</a></code></h4>
+<h4 id="encaseEither2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2431">encaseEither2 <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either l r</a></code></h4>
 
 <p>Binary version of <a href="#encaseEither"><code>encaseEither</code></a>.</p>
 <p>See also <a href="#encaseEither2_"><code>encaseEither2_</code></a>.</p>
 <a class="pilcrow h4" href="#encaseEither2_">¶</a>
-<h4 id="encaseEither2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2445">encaseEither2_ <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either l r</a></code></h4>
+<h4 id="encaseEither2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2445">encaseEither2_ <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either l r</a></code></h4>
 
 <p>Variant of <a href="#encaseEither2"><code>encaseEither2</code></a> which takes an uncurried
 binary function.</p>
 <a class="pilcrow h4" href="#encaseEither3">¶</a>
-<h4 id="encaseEither3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2462">encaseEither3 <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either l r</a></code></h4>
+<h4 id="encaseEither3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2462">encaseEither3 <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either l r</a></code></h4>
 
 <p>Ternary version of <a href="#encaseEither"><code>encaseEither</code></a>.</p>
 <p>See also <a href="#encaseEither3_"><code>encaseEither3_</code></a>.</p>
 <a class="pilcrow h4" href="#encaseEither3_">¶</a>
-<h4 id="encaseEither3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2476">encaseEither3_ <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Either l r</a></code></h4>
+<h4 id="encaseEither3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2476">encaseEither3_ <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> c <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Either l r</a></code></h4>
 
 <p>Variant of <a href="#encaseEither3"><code>encaseEither3</code></a> which takes an uncurried
 ternary function.</p>
 <a class="pilcrow h4" href="#eitherToMaybe">¶</a>
-<h4 id="eitherToMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2493">eitherToMaybe <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</a></code></h4>
+<h4 id="eitherToMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2493">eitherToMaybe <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</a></code></h4>
 
 <p>Converts an Either to a Maybe. A Left becomes Nothing; a Right becomes
 a Just.</p>
@@ -2794,7 +2794,7 @@ a Just.</p>
 <a class="pilcrow h3" href="#logic">¶</a>
 <h3 id="logic">Logic</h3>
 <a class="pilcrow h4" href="#and">¶</a>
-<h4 id="and"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2515">and <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="and"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2515">and <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Boolean &quot;and&quot;.</p>
 <div class="examples">
@@ -2817,7 +2817,7 @@ a Just.</p>
 </div>
 
 <a class="pilcrow h4" href="#or">¶</a>
-<h4 id="or"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2537">or <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="or"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2537">or <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Boolean &quot;or&quot;.</p>
 <div class="examples">
@@ -2840,7 +2840,7 @@ a Just.</p>
 </div>
 
 <a class="pilcrow h4" href="#not">¶</a>
-<h4 id="not"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2559">not <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="not"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2559">not <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Boolean &quot;not&quot;.</p>
 <div class="examples">
@@ -2855,7 +2855,7 @@ a Just.</p>
 </div>
 
 <a class="pilcrow h4" href="#ifElse">¶</a>
-<h4 id="ifElse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2575">ifElse <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="ifElse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2575">ifElse <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>Takes a unary predicate, a unary &quot;if&quot; function, a unary &quot;else&quot;
 function, and a value of any type, and returns the result of
@@ -2874,7 +2874,7 @@ value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#allPass">¶</a>
-<h4 id="allPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2595">allPass <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="allPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2595">allPass <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Takes an array of unary predicates and a value of any type
 and returns <code>true</code> if all the predicates pass; <code>false</code> otherwise.
@@ -2892,7 +2892,7 @@ first failed predicate.</p>
 </div>
 
 <a class="pilcrow h4" href="#anyPass">¶</a>
-<h4 id="anyPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2614">anyPass <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="anyPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2614">anyPass <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Takes an array of unary predicates and a value of any type
 and returns <code>true</code> if any of the predicates pass; <code>false</code> otherwise.
@@ -2932,7 +2932,7 @@ replaced with the latter:</p>
 </code></pre><p>It&#39;s then apparent that the first argument needn&#39;t be a single-character
 string; the correspondence between arrays and strings does not hold.</p>
 <a class="pilcrow h4" href="#concat">¶</a>
-<h4 id="concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2665">concat <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</a></code></h4>
+<h4 id="concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2665">concat <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</a></code></h4>
 
 <p>Concatenates two (homogeneous) arrays, two strings, or two values of any
 other type which satisfies the <a href="https://github.com/fantasyland/fantasy-land/tree/v3.0.0#semigroup">Semigroup</a> specification.</p>
@@ -2952,7 +2952,7 @@ other type which satisfies the <a href="https://github.com/fantasyland/fantasy-l
 </div>
 
 <a class="pilcrow h4" href="#slice">¶</a>
-<h4 id="slice"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2682">slice <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="slice"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2682">slice <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</a></code></h4>
 
 <p>Returns Just a list containing the elements from the supplied list
 from a beginning index (inclusive) to an end index (exclusive).
@@ -2984,7 +2984,7 @@ the list.</p>
 </div>
 
 <a class="pilcrow h4" href="#at">¶</a>
-<h4 id="at"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2719">at <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="at"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2719">at <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Takes an index and a list and returns Just the element of the list at
 the index if the index is within the list&#39;s bounds; Nothing otherwise.
@@ -3005,7 +3005,7 @@ A negative index represents an offset from the length of the list.</p>
 </div>
 
 <a class="pilcrow h4" href="#head">¶</a>
-<h4 id="head"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2740">head <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="head"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2740">head <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Takes a list and returns Just the first element of the list if the
 list contains at least one element; Nothing if the list is empty.</p>
@@ -3021,7 +3021,7 @@ list contains at least one element; Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#last">¶</a>
-<h4 id="last"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2757">last <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="last"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2757">last <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Takes a list and returns Just the last element of the list if the
 list contains at least one element; Nothing if the list is empty.</p>
@@ -3037,7 +3037,7 @@ list contains at least one element; Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#tail">¶</a>
-<h4 id="tail"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2774">tail <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="tail"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2774">tail <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</a></code></h4>
 
 <p>Takes a list and returns Just a list containing all but the first
 of the list&#39;s elements if the list contains at least one element;
@@ -3054,7 +3054,7 @@ Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#init">¶</a>
-<h4 id="init"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2792">init <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="init"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2792">init <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</a></code></h4>
 
 <p>Takes a list and returns Just a list containing all but the last
 of the list&#39;s elements if the list contains at least one element;
@@ -3071,7 +3071,7 @@ Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#take">¶</a>
-<h4 id="take"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2810">take <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="take"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2810">take <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</a></code></h4>
 
 <p>Returns Just the first N elements of the given collection if N is
 greater than or equal to zero and less than or equal to the length
@@ -3092,7 +3092,7 @@ of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#takeLast">¶</a>
-<h4 id="takeLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2831">takeLast <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="takeLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2831">takeLast <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</a></code></h4>
 
 <p>Returns Just the last N elements of the given collection if N is
 greater than or equal to zero and less than or equal to the length
@@ -3113,7 +3113,7 @@ of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#drop">¶</a>
-<h4 id="drop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2853">drop <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="drop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2853">drop <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</a></code></h4>
 
 <p>Returns Just all but the first N elements of the given collection
 if N is greater than or equal to zero and less than or equal to the
@@ -3134,7 +3134,7 @@ length of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#dropLast">¶</a>
-<h4 id="dropLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2874">dropLast <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="dropLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2874">dropLast <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (List a)</a></code></h4>
 
 <p>Returns Just all but the last N elements of the given collection
 if N is greater than or equal to zero and less than or equal to the
@@ -3155,7 +3155,7 @@ length of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#reverse">¶</a>
-<h4 id="reverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2896">reverse <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a</a></code></h4>
+<h4 id="reverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2896">reverse <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a</a></code></h4>
 
 <p>Returns the elements of the given list in reverse order.</p>
 <div class="examples">
@@ -3170,7 +3170,7 @@ length of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#indexOf">¶</a>
-<h4 id="indexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2913">indexOf <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe Integer</a></code></h4>
+<h4 id="indexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2913">indexOf <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe Integer</a></code></h4>
 
 <p>Takes a value of any type and a list, and returns Just the index
 of the first occurrence of the value in the list, if applicable;
@@ -3195,7 +3195,7 @@ Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#lastIndexOf">¶</a>
-<h4 id="lastIndexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2938">lastIndexOf <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe Integer</a></code></h4>
+<h4 id="lastIndexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2938">lastIndexOf <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe Integer</a></code></h4>
 
 <p>Takes a value of any type and a list, and returns Just the index
 of the last occurrence of the value in the list, if applicable;
@@ -3222,7 +3222,7 @@ Nothing otherwise.</p>
 <a class="pilcrow h3" href="#array">¶</a>
 <h3 id="array">Array</h3>
 <a class="pilcrow h4" href="#append">¶</a>
-<h4 id="append"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2966">append <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</a></code></h4>
+<h4 id="append"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2966">append <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</a></code></h4>
 
 <p>Takes a value of any type and an array of values of that type, and
 returns the result of appending the value to the array.</p>
@@ -3235,7 +3235,7 @@ returns the result of appending the value to the array.</p>
 </div>
 
 <a class="pilcrow h4" href="#prepend">¶</a>
-<h4 id="prepend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2982">prepend <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</a></code></h4>
+<h4 id="prepend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2982">prepend <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</a></code></h4>
 
 <p>Takes a value of any type and an array of values of that type, and
 returns the result of prepending the value to the array.</p>
@@ -3248,7 +3248,7 @@ returns the result of prepending the value to the array.</p>
 </div>
 
 <a class="pilcrow h4" href="#joinWith">¶</a>
-<h4 id="joinWith"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2998">joinWith <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="joinWith"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L2998">joinWith <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Joins the strings of the second argument separated by the first argument.</p>
 <p>Properties:</p>
@@ -3264,7 +3264,7 @@ returns the result of prepending the value to the array.</p>
 </div>
 
 <a class="pilcrow h4" href="#find">¶</a>
-<h4 id="find"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3018">find <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe a</a></code></h4>
+<h4 id="find"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3018">find <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe a</a></code></h4>
 
 <p>Takes a predicate and an array and returns Just the leftmost element of
 the array which satisfies the predicate; Nothing if none of the array&#39;s
@@ -3281,7 +3281,7 @@ elements satisfies the predicate.</p>
 </div>
 
 <a class="pilcrow h4" href="#pluck">¶</a>
-<h4 id="pluck"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3042">pluck <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array b</a></code></h4>
+<h4 id="pluck"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3042">pluck <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array b</a></code></h4>
 
 <p>Combines <a href="#map"><code>map</code></a> and <a href="#prop"><code>prop</code></a>. <code>pluck(k, xs)</code> is equivalent
 to <code>map(prop(k), xs)</code>.</p>
@@ -3293,7 +3293,7 @@ to <code>map(prop(k), xs)</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#unfoldr">¶</a>
-<h4 id="unfoldr"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3065">unfoldr <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe (Pair a b)) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</a></code></h4>
+<h4 id="unfoldr"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3065">unfoldr <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe (Pair a b)) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</a></code></h4>
 
 <p>Takes a function and a seed value, and returns an array generated by
 applying the function repeatedly. The array is initially empty. The
@@ -3314,7 +3314,7 @@ the array and the function is applied to the second element.</p>
 </div>
 
 <a class="pilcrow h4" href="#range">¶</a>
-<h4 id="range"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3089">range <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array Integer</a></code></h4>
+<h4 id="range"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3089">range <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array Integer</a></code></h4>
 
 <p>Returns an array of consecutive integers starting with the first argument
 and ending with the second argument minus one. Returns <code>[]</code> if the second
@@ -3337,7 +3337,7 @@ argument is less than or equal to the first argument.</p>
 <a class="pilcrow h3" href="#object">¶</a>
 <h3 id="object">Object</h3>
 <a class="pilcrow h4" href="#prop">¶</a>
-<h4 id="prop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3115">prop <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="prop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3115">prop <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>Takes a property name and an object with known properties and returns
 the value of the specified property. If for some reason the object
@@ -3352,7 +3352,7 @@ lacks the specified property, a type error is thrown.</p>
 </div>
 
 <a class="pilcrow h4" href="#props">¶</a>
-<h4 id="props"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3136">props <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</a></code></h4>
+<h4 id="props"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3136">props <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> b</a></code></h4>
 
 <p>Takes a property path (an array of property names) and an object with
 known structure and returns the value at the given path. If for some
@@ -3367,7 +3367,7 @@ instead.</p>
 </div>
 
 <a class="pilcrow h4" href="#get">¶</a>
-<h4 id="get"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3159">get <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe c</a></code></h4>
+<h4 id="get"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3159">get <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe c</a></code></h4>
 
 <p>Takes a predicate, a property name, and an object and returns Just the
 value of the specified object property if it exists and the value
@@ -3389,7 +3389,7 @@ satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#gets">¶</a>
-<h4 id="gets"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3184">gets <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe c</a></code></h4>
+<h4 id="gets"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3184">gets <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe c</a></code></h4>
 
 <p>Takes a predicate, a property path (an array of property names), and
 an object and returns Just the value at the given path if such a path
@@ -3411,7 +3411,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#keys">¶</a>
-<h4 id="keys"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3215">keys <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String</a></code></h4>
+<h4 id="keys"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3215">keys <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String</a></code></h4>
 
 <p>Returns the keys of the given string map, in arbitrary order.</p>
 <div class="examples">
@@ -3422,7 +3422,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#values">¶</a>
-<h4 id="values"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3225">values <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array a</a></code></h4>
+<h4 id="values"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3225">values <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array a</a></code></h4>
 
 <p>Returns the values of the given string map, in arbitrary order.</p>
 <div class="examples">
@@ -3433,7 +3433,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#pairs">¶</a>
-<h4 id="pairs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3238">pairs <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array (Pair String a)</a></code></h4>
+<h4 id="pairs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3238">pairs <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array (Pair String a)</a></code></h4>
 
 <p>Returns the key–value pairs of the given string map, in arbitrary order.</p>
 <div class="examples">
@@ -3446,7 +3446,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 <a class="pilcrow h3" href="#number">¶</a>
 <h3 id="number">Number</h3>
 <a class="pilcrow h4" href="#negate">¶</a>
-<h4 id="negate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3254">negate <span class="tight">:</span><span class="tight">:</span> ValidNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> ValidNumber</a></code></h4>
+<h4 id="negate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3254">negate <span class="tight">:</span><span class="tight">:</span> ValidNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> ValidNumber</a></code></h4>
 
 <p>Negates its argument.</p>
 <div class="examples">
@@ -3461,7 +3461,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#add">¶</a>
-<h4 id="add"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3270">add <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="add"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3270">add <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</a></code></h4>
 
 <p>Returns the sum of two (finite) numbers.</p>
 <div class="examples">
@@ -3472,7 +3472,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sum">¶</a>
-<h4 id="sum"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3284">sum <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="sum"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3284">sum <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</a></code></h4>
 
 <p>Returns the sum of the given array of (finite) numbers.</p>
 <div class="examples">
@@ -3495,7 +3495,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sub">¶</a>
-<h4 id="sub"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3307">sub <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="sub"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3307">sub <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</a></code></h4>
 
 <p>Returns the difference between two (finite) numbers.</p>
 <div class="examples">
@@ -3506,7 +3506,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#inc">¶</a>
-<h4 id="inc"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3321">inc <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="inc"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3321">inc <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</a></code></h4>
 
 <p>Increments a (finite) number by one.</p>
 <div class="examples">
@@ -3517,7 +3517,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#dec">¶</a>
-<h4 id="dec"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3334">dec <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="dec"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3334">dec <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</a></code></h4>
 
 <p>Decrements a (finite) number by one.</p>
 <div class="examples">
@@ -3528,7 +3528,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#mult">¶</a>
-<h4 id="mult"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3347">mult <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="mult"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3347">mult <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</a></code></h4>
 
 <p>Returns the product of two (finite) numbers.</p>
 <div class="examples">
@@ -3539,7 +3539,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#product">¶</a>
-<h4 id="product"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3361">product <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="product"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3361">product <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</a></code></h4>
 
 <p>Returns the product of the given array of (finite) numbers.</p>
 <div class="examples">
@@ -3562,7 +3562,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#div">¶</a>
-<h4 id="div"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3387">div <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> NonZeroFiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="div"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3387">div <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> NonZeroFiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> FiniteNumber</a></code></h4>
 
 <p>Returns the result of dividing its first argument (a finite number) by
 its second argument (a non-zero finite number).</p>
@@ -3574,7 +3574,7 @@ its second argument (a non-zero finite number).</p>
 </div>
 
 <a class="pilcrow h4" href="#mean">¶</a>
-<h4 id="mean"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3402">mean <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe FiniteNumber</a></code></h4>
+<h4 id="mean"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3402">mean <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe FiniteNumber</a></code></h4>
 
 <p>Returns the mean of the given array of (finite) numbers.</p>
 <div class="examples">
@@ -3597,7 +3597,7 @@ its second argument (a non-zero finite number).</p>
 </div>
 
 <a class="pilcrow h4" href="#min">¶</a>
-<h4 id="min"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3437">min <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</a></code></h4>
+<h4 id="min"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3437">min <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</a></code></h4>
 
 <p>Returns the smaller of its two arguments.</p>
 <p>Strings are compared lexicographically. Specifically, the Unicode
@@ -3620,7 +3620,7 @@ to the value of the corresponding character in the second string.</p>
 </div>
 
 <a class="pilcrow h4" href="#max">¶</a>
-<h4 id="max"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3462">max <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</a></code></h4>
+<h4 id="max"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3462">max <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> a</a></code></h4>
 
 <p>Returns the larger of its two arguments.</p>
 <p>Strings are compared lexicographically. Specifically, the Unicode
@@ -3645,7 +3645,7 @@ to the value of the corresponding character in the second string.</p>
 <a class="pilcrow h3" href="#integer">¶</a>
 <h3 id="integer">Integer</h3>
 <a class="pilcrow h4" href="#even">¶</a>
-<h4 id="even"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3489">even <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="even"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3489">even <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given integer is even; <code>false</code> if it is odd.</p>
 <div class="examples">
@@ -3660,7 +3660,7 @@ to the value of the corresponding character in the second string.</p>
 </div>
 
 <a class="pilcrow h4" href="#odd">¶</a>
-<h4 id="odd"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3505">odd <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="odd"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3505">odd <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given integer is odd; <code>false</code> if it is even.</p>
 <div class="examples">
@@ -3677,7 +3677,7 @@ to the value of the corresponding character in the second string.</p>
 <a class="pilcrow h3" href="#parse">¶</a>
 <h3 id="parse">Parse</h3>
 <a class="pilcrow h4" href="#parseDate">¶</a>
-<h4 id="parseDate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3523">parseDate <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe Date</a></code></h4>
+<h4 id="parseDate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3523">parseDate <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe Date</a></code></h4>
 
 <p>Takes a string and returns Just the date represented by the string
 if it does in fact represent a date; Nothing otherwise.</p>
@@ -3693,7 +3693,7 @@ if it does in fact represent a date; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#parseFloat">¶</a>
-<h4 id="parseFloat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3575">parseFloat <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe Number</a></code></h4>
+<h4 id="parseFloat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3575">parseFloat <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe Number</a></code></h4>
 
 <p>Takes a string and returns Just the number represented by the string
 if it does in fact represent a number; Nothing otherwise.</p>
@@ -3709,7 +3709,7 @@ if it does in fact represent a number; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#parseInt">¶</a>
-<h4 id="parseInt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3593">parseInt <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe Integer</a></code></h4>
+<h4 id="parseInt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3593">parseInt <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe Integer</a></code></h4>
 
 <p>Takes a radix (an integer between 2 and 36 inclusive) and a string,
 and returns Just the number represented by the string if it does in
@@ -3734,7 +3734,7 @@ characters are members of the character set specified by the radix.</p>
 </div>
 
 <a class="pilcrow h4" href="#parseJson">¶</a>
-<h4 id="parseJson"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3632">parseJson <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</a></code></h4>
+<h4 id="parseJson"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3632">parseJson <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe b</a></code></h4>
 
 <p>Takes a predicate and a string which may or may not be valid JSON, and
 returns Just the result of applying <code>JSON.parse</code> to the string <em>if</em> the
@@ -3757,7 +3757,7 @@ result satisfies the predicate; Nothing otherwise.</p>
 <a class="pilcrow h3" href="#regexp">¶</a>
 <h3 id="regexp">RegExp</h3>
 <a class="pilcrow h4" href="#regex">¶</a>
-<h4 id="regex"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3675">regex <span class="tight">:</span><span class="tight">:</span> RegexFlags <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> RegExp</a></code></h4>
+<h4 id="regex"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3675">regex <span class="tight">:</span><span class="tight">:</span> RegexFlags <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> RegExp</a></code></h4>
 
 <p>Takes a <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.9.0#RegexFlags">RegexFlags</a> and a pattern, and returns a RegExp.</p>
 <div class="examples">
@@ -3768,7 +3768,7 @@ result satisfies the predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#regexEscape">¶</a>
-<h4 id="regexEscape"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3688">regexEscape <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="regexEscape"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3688">regexEscape <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Takes a string which may contain regular expression metacharacters,
 and returns a string with those metacharacters escaped.</p>
@@ -3784,7 +3784,7 @@ and returns a string with those metacharacters escaped.</p>
 </div>
 
 <a class="pilcrow h4" href="#test">¶</a>
-<h4 id="test"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3706">test <span class="tight">:</span><span class="tight">:</span> RegExp <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean</a></code></h4>
+<h4 id="test"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3706">test <span class="tight">:</span><span class="tight">:</span> RegExp <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Boolean</a></code></h4>
 
 <p>Takes a pattern and a string, and returns <code>true</code> if the pattern
 matches the string; <code>false</code> otherwise.</p>
@@ -3800,7 +3800,7 @@ matches the string; <code>false</code> otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#match">¶</a>
-<h4 id="match"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3723">match <span class="tight">:</span><span class="tight">:</span> NonGlobalRegExp <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</a></code></h4>
+<h4 id="match"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3723">match <span class="tight">:</span><span class="tight">:</span> NonGlobalRegExp <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Maybe { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</a></code></h4>
 
 <p>Takes a pattern and a string, and returns Just a match record if the
 pattern matches the string; Nothing otherwise.</p>
@@ -3824,7 +3824,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#matchAll">¶</a>
-<h4 id="matchAll"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3751">matchAll <span class="tight">:</span><span class="tight">:</span> GlobalRegExp <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</a></code></h4>
+<h4 id="matchAll"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3751">matchAll <span class="tight">:</span><span class="tight">:</span> GlobalRegExp <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</a></code></h4>
 
 <p>Takes a pattern and a string, and returns an array of match records.</p>
 <p><code>groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String)</code> acknowledges the existence of optional
@@ -3844,7 +3844,7 @@ capturing groups.</p>
 <a class="pilcrow h3" href="#string">¶</a>
 <h3 id="string">String</h3>
 <a class="pilcrow h4" href="#toUpper">¶</a>
-<h4 id="toUpper"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3783">toUpper <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="toUpper"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3783">toUpper <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Returns the upper-case equivalent of its argument.</p>
 <p>See also <a href="#toLower"><code>toLower</code></a>.</p>
@@ -3856,7 +3856,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#toLower">¶</a>
-<h4 id="toLower"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3798">toLower <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="toLower"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3798">toLower <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Returns the lower-case equivalent of its argument.</p>
 <p>See also <a href="#toUpper"><code>toUpper</code></a>.</p>
@@ -3868,7 +3868,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#trim">¶</a>
-<h4 id="trim"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3813">trim <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="trim"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3813">trim <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Strips leading and trailing whitespace characters.</p>
 <div class="examples">
@@ -3879,7 +3879,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#words">¶</a>
-<h4 id="words"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3826">words <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String</a></code></h4>
+<h4 id="words"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3826">words <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String</a></code></h4>
 
 <p>Takes a string and returns the array of words the string contains
 (words are delimited by whitespace characters).</p>
@@ -3892,7 +3892,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#unwords">¶</a>
-<h4 id="unwords"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3844">unwords <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="unwords"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3844">unwords <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Takes an array of words and returns the result of joining the words
 with separating spaces.</p>
@@ -3905,7 +3905,7 @@ with separating spaces.</p>
 </div>
 
 <a class="pilcrow h4" href="#lines">¶</a>
-<h4 id="lines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3860">lines <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String</a></code></h4>
+<h4 id="lines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3860">lines <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String</a></code></h4>
 
 <p>Takes a string and returns the array of lines the string contains
 (lines are delimited by newlines: <code>&#39;\n&#39;</code> or <code>&#39;\r\n&#39;</code> or <code>&#39;\r&#39;</code>).
@@ -3919,7 +3919,7 @@ The resulting strings do not contain newlines.</p>
 </div>
 
 <a class="pilcrow h4" href="#unlines">¶</a>
-<h4 id="unlines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3878">unlines <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</a></code></h4>
+<h4 id="unlines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3878">unlines <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String</a></code></h4>
 
 <p>Takes an array of lines and returns the result of joining the lines
 after appending a terminating line feed (<code>&#39;\n&#39;</code>) to each.</p>
@@ -3932,7 +3932,7 @@ after appending a terminating line feed (<code>&#39;\n&#39;</code>) to each.</p>
 </div>
 
 <a class="pilcrow h4" href="#splitOn">¶</a>
-<h4 id="splitOn"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3894">splitOn <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Array String</a></code></h4>
+<h4 id="splitOn"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.12.1/index.js#L3894">splitOn <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> String <span class="arrow"><span class="arrow-hyphen">&#x2011;</span>&gt;</span> Array String</a></code></h4>
 
 <p>Returns the substrings of its second argument separated by occurrences
 of its first argument.</p>

--- a/scripts/generate
+++ b/scripts/generate
@@ -191,7 +191,9 @@ def('substitutions',
                           K(el('span', 'arrow', htmlEncode('~>')))],
                          [contains(_, ap([I, htmlEncode], ['->'])),
                           K(el('span', 'arrow',
-                               el('span', 'arrow-hyphen', htmlEncode('-')) +
+                               //  Use NON-BREAKING HYPHEN so arrow does
+                               //  not break because of line wrapping
+                               el('span', 'arrow-hyphen', '&#x2011;') +
                                htmlEncode('>')))],
                          [equals('...'),
                           K(el('span', 'tight', '.') +


### PR DESCRIPTION
Right now long type signatures (e.g. [`filter`](https://sanctuary.js.org/#filter)) sometimes line-wrap in the middle of `->`:

![`filter` signature with hyphen-minus](https://cloud.githubusercontent.com/assets/389387/23177307/621a6d72-f877-11e6-8aba-73403ec0de98.png)

We can use [non-breaking hyphens](http://graphemica.com/%E2%80%91) instead to make sure `->` is always displayed as intended:

![`filter` signature with non-breaking hyphen](https://cloud.githubusercontent.com/assets/389387/23177363/97f6c1b6-f877-11e6-97b8-d835d2f0b621.png)
