### PR TITLE
generate: link to type and type class documentation from type signatures

### DIFF
--- a/index.html
+++ b/index.html
@@ -923,7 +923,7 @@ const S = create({checkTypes, env});
 <a class="pilcrow h2" href="#api">¶</a>
 <h2 id="api">API</h2>
 <a class="pilcrow h4" href="#create">¶</a>
-<h4 id="create"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L381">create <span class="tight">:</span><span class="tight">:</span> { checkTypes <span class="tight">:</span><span class="tight">:</span> Boolean, env <span class="tight">:</span><span class="tight">:</span> Array Type } <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Module</a></code></h4>
+<h4 id="create"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L381">create</a> <span class="tight">:</span><span class="tight">:</span> { checkTypes <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>, env <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Type">Type</a> } <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Module</code></h4>
 
 <p>Takes an options record and returns a Sanctuary module. <code>checkTypes</code>
 specifies whether to enable type checking. The module&#39;s polymorphic
@@ -969,7 +969,7 @@ S.map(S.sub(1), Identity(43));
 </code></pre>
 <p>See also <a href="#env"><code>env</code></a>.</p>
 <a class="pilcrow h4" href="#env">¶</a>
-<h4 id="env"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L437">env <span class="tight">:</span><span class="tight">:</span> Array Type</a></code></h4>
+<h4 id="env"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L437">env</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Type">Type</a></code></h4>
 
 <p>The default environment, which may be used as is or as the basis of a
 custom environment in conjunction with <a href="#create"><code>create</code></a>.</p>
@@ -994,7 +994,7 @@ The following are all equivalent (<code>_</code> represents the placeholder):</p
 <li><code>f(_, _, z)(_, y)(x)</code></li>
 </ul>
 <a class="pilcrow h4" href="#__">¶</a>
-<h4 id="__"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L467">__ <span class="tight">:</span><span class="tight">:</span> Placeholder</a></code></h4>
+<h4 id="__"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L467">__</a> <span class="tight">:</span><span class="tight">:</span> Placeholder</code></h4>
 
 <p>The special <a href="#placeholder">placeholder</a> value.</p>
 <div class="examples">
@@ -1011,7 +1011,7 @@ The following are all equivalent (<code>_</code> represents the placeholder):</p
 <a class="pilcrow h3" href="#classify">¶</a>
 <h3 id="classify">Classify</h3>
 <a class="pilcrow h4" href="#type">¶</a>
-<h4 id="type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L482">type <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> { namespace <span class="tight">:</span><span class="tight">:</span> Maybe String, name <span class="tight">:</span><span class="tight">:</span> String, version <span class="tight">:</span><span class="tight">:</span> Integer }</a></code></h4>
+<h4 id="type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L482">type</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Any">Any</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> { namespace <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a>, name <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a>, version <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> }</code></h4>
 
 <p>Returns the result of parsing the <a href="https://github.com/sanctuary-js/sanctuary-type-identifiers/tree/v2.0.1">type identifier</a> of the given value.</p>
 <div class="examples">
@@ -1026,7 +1026,7 @@ The following are all equivalent (<code>_</code> represents the placeholder):</p
 </div>
 
 <a class="pilcrow h4" href="#is">¶</a>
-<h4 id="is"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L506">is <span class="tight">:</span><span class="tight">:</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="is"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L506">is</a> <span class="tight">:</span><span class="tight">:</span> <a href="#type-representatives">TypeRep</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Any">Any</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Takes a <a href="#type-representatives">type representative</a> and a value of
 any type and returns <code>true</code> if the given value is of the specified
@@ -1049,7 +1049,7 @@ type; <code>false</code> otherwise. Subtyping is not respected.</p>
 <a class="pilcrow h3" href="#showable">¶</a>
 <h3 id="showable">Showable</h3>
 <a class="pilcrow h4" href="#toString">¶</a>
-<h4 id="toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L535">toString <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L535">toString</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Any">Any</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Alias of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#toString"><code>Z.toString</code></a>.</p>
 <div class="examples">
@@ -1075,7 +1075,7 @@ type; <code>false</code> otherwise. Subtyping is not respected.</p>
 <h3 id="fantasy-land">Fantasy Land</h3>
 <p>Sanctuary is compatible with the <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0">Fantasy Land</a> specification.</p>
 <a class="pilcrow h4" href="#equals">¶</a>
-<h4 id="equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L558">equals <span class="tight">:</span><span class="tight">:</span> Setoid a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L558">equals</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#equals"><code>Z.equals</code></a> which requires two arguments of the
 same type.</p>
@@ -1102,7 +1102,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#lt">¶</a>
-<h4 id="lt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L582">lt <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean)</a></code></h4>
+<h4 id="lt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L582">lt</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>)</code></h4>
 
 <p>Flipped version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lt"><code>Z.lt</code></a> intended for partial application.</p>
 <p>See also <a href="#lt_"><code>lt_</code></a>.</p>
@@ -1114,7 +1114,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#lt_">¶</a>
-<h4 id="lt_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L594">lt_ <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="lt_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L594">lt_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lt"><code>Z.lt</code></a>.</p>
 <p>See also <a href="#lt"><code>lt</code></a>.</p>
@@ -1134,7 +1134,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#lte">¶</a>
-<h4 id="lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L612">lte <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean)</a></code></h4>
+<h4 id="lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L612">lte</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>)</code></h4>
 
 <p>Flipped version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a> intended for partial application.</p>
 <p>See also <a href="#lte_"><code>lte_</code></a>.</p>
@@ -1146,7 +1146,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#lte_">¶</a>
-<h4 id="lte_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L624">lte_ <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="lte_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L624">lte_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a>.</p>
 <p>See also <a href="#lte"><code>lte</code></a>.</p>
@@ -1166,7 +1166,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#gt">¶</a>
-<h4 id="gt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L642">gt <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean)</a></code></h4>
+<h4 id="gt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L642">gt</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>)</code></h4>
 
 <p>Flipped version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#gt"><code>Z.gt</code></a> intended for partial application.</p>
 <p>See also <a href="#gt_"><code>gt_</code></a>.</p>
@@ -1178,7 +1178,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#gt_">¶</a>
-<h4 id="gt_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L654">gt_ <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="gt_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L654">gt_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#gt"><code>Z.gt</code></a>.</p>
 <p>See also <a href="#gt"><code>gt</code></a>.</p>
@@ -1198,7 +1198,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#gte">¶</a>
-<h4 id="gte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L672">gte <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean)</a></code></h4>
+<h4 id="gte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L672">gte</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>)</code></h4>
 
 <p>Flipped version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#gte"><code>Z.gte</code></a> intended for partial application.</p>
 <p>See also <a href="#gte_"><code>gte_</code></a>.</p>
@@ -1210,7 +1210,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#gte_">¶</a>
-<h4 id="gte_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L684">gte_ <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="gte_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L684">gte_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#gte"><code>Z.gte</code></a>.</p>
 <p>See also <a href="#gte"><code>gte</code></a>.</p>
@@ -1230,7 +1230,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#min">¶</a>
-<h4 id="min"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L702">min <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="min"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L702">min</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p>Returns the smaller of its two arguments (according to <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a>).</p>
 <p>See also <a href="#max"><code>max</code></a>.</p>
@@ -1250,7 +1250,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#max">¶</a>
-<h4 id="max"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L723">max <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="max"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L723">max</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p>Returns the larger of its two arguments (according to <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a>).</p>
 <p>See also <a href="#min"><code>min</code></a>.</p>
@@ -1270,7 +1270,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#id">¶</a>
-<h4 id="id"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L744">id <span class="tight">:</span><span class="tight">:</span> Category c <span class="arrow">=&gt;</span> TypeRep c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</a></code></h4>
+<h4 id="id"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L744">id</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Category">Category</a> c <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#id"><code>Z.id</code></a>.</p>
 <div class="examples">
@@ -1281,7 +1281,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#concat">¶</a>
-<h4 id="concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L754">concat <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L754">concat</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#concat"><code>Z.concat</code></a>.</p>
 <div class="examples">
@@ -1304,7 +1304,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#empty">¶</a>
-<h4 id="empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L773">empty <span class="tight">:</span><span class="tight">:</span> Monoid a <span class="arrow">=&gt;</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L773">empty</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> a <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#empty"><code>Z.empty</code></a>.</p>
 <div class="examples">
@@ -1323,7 +1323,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#map">¶</a>
-<h4 id="map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L789">map <span class="tight">:</span><span class="tight">:</span> Functor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</a></code></h4>
+<h4 id="map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L789">map</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Functor">Functor</a> f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#map"><code>Z.map</code></a>.</p>
 <div class="examples">
@@ -1361,7 +1361,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#bimap">¶</a>
-<h4 id="bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L823">bimap <span class="tight">:</span><span class="tight">:</span> Bifunctor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b d</a></code></h4>
+<h4 id="bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L823">bimap</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Bifunctor">Bifunctor</a> f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b d</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#bimap"><code>Z.bimap</code></a>.</p>
 <div class="examples">
@@ -1376,7 +1376,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#promap">¶</a>
-<h4 id="promap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L840">promap <span class="tight">:</span><span class="tight">:</span> Profunctor p <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> p b c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> p a d</a></code></h4>
+<h4 id="promap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L840">promap</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Profunctor">Profunctor</a> p <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> p b c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> p a d</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#promap"><code>Z.promap</code></a>.</p>
 <div class="examples">
@@ -1387,7 +1387,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#alt">¶</a>
-<h4 id="alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L854">alt <span class="tight">:</span><span class="tight">:</span> Alt f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</a></code></h4>
+<h4 id="alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L854">alt</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alt">Alt</a> f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#alt"><code>Z.alt</code></a>.</p>
 <div class="examples">
@@ -1410,7 +1410,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#zero">¶</a>
-<h4 id="zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L873">zero <span class="tight">:</span><span class="tight">:</span> Plus f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</a></code></h4>
+<h4 id="zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L873">zero</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Plus">Plus</a> f <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#zero"><code>Z.zero</code></a>.</p>
 <div class="examples">
@@ -1429,7 +1429,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#reduce">¶</a>
-<h4 id="reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L890">reduce <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L890">reduce</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>Takes a curried binary function, an initial value, and a <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#foldable">Foldable</a>,
 and applies the function to the initial value and the Foldable&#39;s first
@@ -1451,11 +1451,11 @@ otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#reduce_">¶</a>
-<h4 id="reduce_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L915">reduce_ <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="reduce_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L915">reduce_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>Variant of <a href="#reduce"><code>reduce</code></a> which takes an uncurried binary function.</p>
 <a class="pilcrow h4" href="#traverse">¶</a>
-<h4 id="traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L924">traverse <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> t a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (t b)</a></code></h4>
+<h4 id="traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L924">traverse</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Traversable">Traversable</a> t) <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> t a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (t b)</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#traverse"><code>Z.traverse</code></a>.</p>
 <div class="examples">
@@ -1486,7 +1486,7 @@ otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sequence">¶</a>
-<h4 id="sequence"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L953">sequence <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> t (f a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (t a)</a></code></h4>
+<h4 id="sequence"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L953">sequence</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Traversable">Traversable</a> t) <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> t (f a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (t a)</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#sequence"><code>Z.sequence</code></a>.</p>
 <div class="examples">
@@ -1513,7 +1513,7 @@ otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#ap">¶</a>
-<h4 id="ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L979">ap <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</a></code></h4>
+<h4 id="ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L979">ap</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f <span class="arrow">=&gt;</span> f (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#ap"><code>Z.ap</code></a>.</p>
 <div class="examples">
@@ -1547,7 +1547,7 @@ Function a (b -&gt; c) -&gt; Function a b -&gt; Function a c
 </div>
 
 <a class="pilcrow h4" href="#lift2">¶</a>
-<h4 id="lift2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1014">lift2 <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c</a></code></h4>
+<h4 id="lift2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1014">lift2</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c</code></h4>
 
 <p>Promotes a curried binary function to a function which operates on two
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#apply">Apply</a>s.</p>
@@ -1571,7 +1571,7 @@ Function a (b -&gt; c) -&gt; Function a b -&gt; Function a c
 </div>
 
 <a class="pilcrow h4" href="#lift3">¶</a>
-<h4 id="lift3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1035">lift3 <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f d</a></code></h4>
+<h4 id="lift3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1035">lift3</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f d</code></h4>
 
 <p>Promotes a curried ternary function to a function which operates on three
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#apply">Apply</a>s.</p>
@@ -1587,7 +1587,7 @@ Function a (b -&gt; c) -&gt; Function a b -&gt; Function a c
 </div>
 
 <a class="pilcrow h4" href="#apFirst">¶</a>
-<h4 id="apFirst"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1053">apFirst <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</a></code></h4>
+<h4 id="apFirst"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1053">apFirst</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#apFirst"><code>Z.apFirst</code></a>. Combines two effectful actions,
 keeping only the result of the first. Equivalent to Haskell&#39;s <code>(&lt;*)</code>
@@ -1605,7 +1605,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#apSecond">¶</a>
-<h4 id="apSecond"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1070">apSecond <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</a></code></h4>
+<h4 id="apSecond"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1070">apSecond</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#apSecond"><code>Z.apSecond</code></a>. Combines two effectful actions,
 keeping only the result of the second. Equivalent to Haskell&#39;s <code>(*&gt;)</code>
@@ -1623,7 +1623,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#of">¶</a>
-<h4 id="of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1087">of <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</a></code></h4>
+<h4 id="of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1087">of</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#of"><code>Z.of</code></a>.</p>
 <div class="examples">
@@ -1646,7 +1646,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#chain">¶</a>
-<h4 id="chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1110">chain <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b</a></code></h4>
+<h4 id="chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1110">chain</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Chain">Chain</a> m <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#chain"><code>Z.chain</code></a>.</p>
 <div class="examples">
@@ -1669,7 +1669,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#join">¶</a>
-<h4 id="join"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1129">join <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> m (m a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</a></code></h4>
+<h4 id="join"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1129">join</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Chain">Chain</a> m <span class="arrow">=&gt;</span> m (m a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#join"><code>Z.join</code></a>.
 Removes one level of nesting from a nested monadic structure.</p>
@@ -1701,7 +1701,7 @@ Function x (Function x a) -&gt; Function x a
 </div>
 
 <a class="pilcrow h4" href="#chainRec">¶</a>
-<h4 id="chainRec"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1158">chainRec <span class="tight">:</span><span class="tight">:</span> ChainRec m <span class="arrow">=&gt;</span> TypeRep m <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m (Either a b)) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b</a></code></h4>
+<h4 id="chainRec"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1158">chainRec</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#ChainRec">ChainRec</a> m <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> m <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m (<a href="#EitherType">Either</a> a b)) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b</code></h4>
 
 <p>Performs a <a href="#chain"><code>chain</code></a>-like computation with constant stack usage.
 Similar to <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#chainRec"><code>Z.chainRec</code></a>, but curried and more convenient due to the
@@ -1714,7 +1714,7 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#extend">¶</a>
-<h4 id="extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1183">extend <span class="tight">:</span><span class="tight">:</span> Extend w <span class="arrow">=&gt;</span> (w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> w b</a></code></h4>
+<h4 id="extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1183">extend</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Extend">Extend</a> w <span class="arrow">=&gt;</span> (w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> w b</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#extend"><code>Z.extend</code></a>.</p>
 <div class="examples">
@@ -1725,11 +1725,11 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#extract">¶</a>
-<h4 id="extract"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1194">extract <span class="tight">:</span><span class="tight">:</span> Comonad w <span class="arrow">=&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="extract"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1194">extract</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Comonad">Comonad</a> w <span class="arrow">=&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#extract"><code>Z.extract</code></a>.</p>
 <a class="pilcrow h4" href="#contramap">¶</a>
-<h4 id="contramap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1200">contramap <span class="tight">:</span><span class="tight">:</span> Contravariant f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</a></code></h4>
+<h4 id="contramap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1200">contramap</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Contravariant">Contravariant</a> f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#contramap"><code>Z.contramap</code></a>.</p>
 <div class="examples">
@@ -1740,7 +1740,7 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#filter">¶</a>
-<h4 id="filter"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1214">filter <span class="tight">:</span><span class="tight">:</span> (Applicative f, Foldable f, Monoid (f a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</a></code></h4>
+<h4 id="filter"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1214">filter</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> (f a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#filter"><code>Z.filter</code></a>.</p>
 <p>See also <a href="#filterM"><code>filterM</code></a>.</p>
@@ -1752,7 +1752,7 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#filterM">¶</a>
-<h4 id="filterM"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1230">filterM <span class="tight">:</span><span class="tight">:</span> (Alternative m, Monad m) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</a></code></h4>
+<h4 id="filterM"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1230">filterM</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alternative">Alternative</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monad">Monad</a> m) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#filterM"><code>Z.filterM</code></a>.</p>
 <p>See also <a href="#filter"><code>filter</code></a>.</p>
@@ -1772,7 +1772,7 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#takeWhile">¶</a>
-<h4 id="takeWhile"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1252">takeWhile <span class="tight">:</span><span class="tight">:</span> (Foldable f, Alternative f) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</a></code></h4>
+<h4 id="takeWhile"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1252">takeWhile</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alternative">Alternative</a> f) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
 
 <p>Discards the first inner value which does not satisfy the predicate, and
 all subsequent inner values.</p>
@@ -1788,7 +1788,7 @@ all subsequent inner values.</p>
 </div>
 
 <a class="pilcrow h4" href="#dropWhile">¶</a>
-<h4 id="dropWhile"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1284">dropWhile <span class="tight">:</span><span class="tight">:</span> (Foldable f, Alternative f) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</a></code></h4>
+<h4 id="dropWhile"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1284">dropWhile</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alternative">Alternative</a> f) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
 
 <p>Retains the first inner value which does not satisfy the predicate, and
 all subsequent inner values.</p>
@@ -1806,7 +1806,7 @@ all subsequent inner values.</p>
 <a class="pilcrow h3" href="#combinator">¶</a>
 <h3 id="combinator">Combinator</h3>
 <a class="pilcrow h4" href="#I">¶</a>
-<h4 id="I"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1318">I <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="I"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1318">I</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p>The I combinator. Returns its argument. Equivalent to Haskell&#39;s <code>id</code>
 function.</p>
@@ -1818,7 +1818,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#K">¶</a>
-<h4 id="K"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1332">K <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="K"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1332">K</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p>The K combinator. Takes two values and returns the first. Equivalent to
 Haskell&#39;s <code>const</code> function.</p>
@@ -1834,7 +1834,7 @@ Haskell&#39;s <code>const</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#A">¶</a>
-<h4 id="A"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1349">A <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="A"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1349">A</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>The A combinator. Takes a function and a value, and returns the result
 of applying the function to the value. Equivalent to Haskell&#39;s <code>($)</code>
@@ -1851,7 +1851,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#T">¶</a>
-<h4 id="T"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1367">T <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="T"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1367">T</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>The T (<a href="https://github.com/raganwald-deprecated/homoiconic/blob/master/2008-10-30/thrush.markdown">thrush</a>) combinator. Takes a value and a function, and returns
 the result of applying the function to the value. Equivalent to Haskell&#39;s
@@ -1870,7 +1870,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 <a class="pilcrow h3" href="#function">¶</a>
 <h3 id="function">Function</h3>
 <a class="pilcrow h4" href="#curry2">¶</a>
-<h4 id="curry2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1387">curry2 <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</a></code></h4>
+<h4 id="curry2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1387">curry2</a> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
 
 <p>Curries the given binary function.</p>
 <div class="examples">
@@ -1885,7 +1885,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#curry3">¶</a>
-<h4 id="curry3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1407">curry3 <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d</a></code></h4>
+<h4 id="curry3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1407">curry3</a> <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d</code></h4>
 
 <p>Curries the given ternary function.</p>
 <div class="examples">
@@ -1904,7 +1904,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#curry4">¶</a>
-<h4 id="curry4"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1432">curry4 <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e</a></code></h4>
+<h4 id="curry4"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1432">curry4</a> <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e</code></h4>
 
 <p>Curries the given quaternary function.</p>
 <div class="examples">
@@ -1923,7 +1923,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#curry5">¶</a>
-<h4 id="curry5"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1457">curry5 <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d, e) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f</a></code></h4>
+<h4 id="curry5"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1457">curry5</a> <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d, e) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f</code></h4>
 
 <p>Curries the given quinary function.</p>
 <div class="examples">
@@ -1942,7 +1942,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#flip">¶</a>
-<h4 id="flip"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1486">flip <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</a></code></h4>
+<h4 id="flip"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1486">flip</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
 
 <p>Takes a curried binary function and two values, and returns the
 result of applying the function to the values in reverse order.</p>
@@ -1955,13 +1955,13 @@ result of applying the function to the values in reverse order.</p>
 </div>
 
 <a class="pilcrow h4" href="#flip_">¶</a>
-<h4 id="flip_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1502">flip_ <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</a></code></h4>
+<h4 id="flip_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1502">flip_</a> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
 
 <p>Variant of <a href="#flip"><code>flip</code></a> which takes an uncurried binary function.</p>
 <a class="pilcrow h3" href="#composition">¶</a>
 <h3 id="composition">Composition</h3>
 <a class="pilcrow h4" href="#compose">¶</a>
-<h4 id="compose"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1512">compose <span class="tight">:</span><span class="tight">:</span> Semigroupoid s <span class="arrow">=&gt;</span> s b c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> s a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> s a c</a></code></h4>
+<h4 id="compose"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1512">compose</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroupoid">Semigroupoid</a> s <span class="arrow">=&gt;</span> s b c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> s a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> s a c</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#compose"><code>Z.compose</code></a>.</p>
 <p>When specialized to Function, <code>compose</code> composes two unary functions,
@@ -1977,7 +1977,7 @@ with any <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#semigr
 </div>
 
 <a class="pilcrow h4" href="#pipe">¶</a>
-<h4 id="pipe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1534">pipe <span class="tight">:</span><span class="tight">:</span> [(a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b), (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c), <span class="tight">.</span><span class="tight">.</span><span class="tight">.</span>, (m <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> n)] <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> n</a></code></h4>
+<h4 id="pipe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1534">pipe</a> <span class="tight">:</span><span class="tight">:</span> [(a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b), (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c), <span class="tight">.</span><span class="tight">.</span><span class="tight">.</span>, (m <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> n)] <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> n</code></h4>
 
 <p>Takes an array of functions assumed to be unary and a value of any type,
 and returns the result of applying the sequence of transformations to
@@ -1992,7 +1992,7 @@ of functions. <code>pipe([f, g, h], x)</code> is equivalent to <code>h(g(f(x)))<
 </div>
 
 <a class="pilcrow h4" href="#on">¶</a>
-<h4 id="on"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1552">on <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</a></code></h4>
+<h4 id="on"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1552">on</a> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
 
 <p>Takes a binary function <code>f</code>, a unary function <code>g</code>, and two
 values <code>x</code> and <code>y</code>. Returns <code>f(g(x))(g(y))</code>.</p>
@@ -2006,7 +2006,7 @@ values <code>x</code> and <code>y</code>. Returns <code>f(g(x))(g(y))</code>.</p
 </div>
 
 <a class="pilcrow h4" href="#on_">¶</a>
-<h4 id="on_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1570">on_ <span class="tight">:</span><span class="tight">:</span> ((b, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</a></code></h4>
+<h4 id="on_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1570">on_</a> <span class="tight">:</span><span class="tight">:</span> ((b, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
 
 <p>Variant of <a href="#on"><code>on</code></a> which takes an uncurried binary function.</p>
 <a class="pilcrow h3" href="#maybe-type">¶</a>
@@ -2016,15 +2016,15 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 <p>The Maybe type satisfies the <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#setoid">Setoid</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#monoid">Monoid</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#monad">Monad</a>,
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#alternative">Alternative</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#traversable">Traversable</a>, and <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#extend">Extend</a> specifications.</p>
 <a class="pilcrow h4" href="#MaybeType">¶</a>
-<h4 id="MaybeType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1586">MaybeType <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Type</a></code></h4>
+<h4 id="MaybeType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1586">MaybeType</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Type">Type</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Type">Type</a></code></h4>
 
 <p>A <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#UnaryType"><code>UnaryType</code></a> for use with <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0">sanctuary-def</a>.</p>
 <a class="pilcrow h4" href="#Maybe">¶</a>
-<h4 id="Maybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1591">Maybe <span class="tight">:</span><span class="tight">:</span> TypeRep Maybe</a></code></h4>
+<h4 id="Maybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1591">Maybe</a> <span class="tight">:</span><span class="tight">:</span> <a href="#type-representatives">TypeRep</a> <a href="#MaybeType">Maybe</a></code></h4>
 
 <p>The <a href="#type-representatives">type representative</a> for the Maybe type.</p>
 <a class="pilcrow h4" href="#Nothing">¶</a>
-<h4 id="Nothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1618">Nothing <span class="tight">:</span><span class="tight">:</span> Maybe a</a></code></h4>
+<h4 id="Nothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1618">Nothing</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Nothing.</p>
 <div class="examples">
@@ -2035,7 +2035,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Just">¶</a>
-<h4 id="Just"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1628">Just <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="Just"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1628">Just</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a value of any type and returns a Just with the given value.</p>
 <div class="examples">
@@ -2046,11 +2046,11 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.@@type">¶</a>
-<h4 id="Maybe.@@type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1641">Maybe.@@type <span class="tight">:</span><span class="tight">:</span> String</a></code></h4>
+<h4 id="Maybe.@@type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1641">Maybe.@@type</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Maybe type identifier, <code>&#39;sanctuary/Maybe&#39;</code>.</p>
 <a class="pilcrow h4" href="#Maybe.fantasy-land/empty">¶</a>
-<h4 id="Maybe.fantasy-land/empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1646">Maybe.fantasy-land/empty <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="Maybe.fantasy-land/empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1646">Maybe.fantasy-land/empty</a> <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Returns Nothing.</p>
 <div class="examples">
@@ -2061,7 +2061,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.fantasy-land/of">¶</a>
-<h4 id="Maybe.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1656">Maybe.fantasy-land/of <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="Maybe.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1656">Maybe.fantasy-land/of</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a value of any type and returns a Just with the given value.</p>
 <div class="examples">
@@ -2072,7 +2072,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.fantasy-land/zero">¶</a>
-<h4 id="Maybe.fantasy-land/zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1666">Maybe.fantasy-land/zero <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="Maybe.fantasy-land/zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1666">Maybe.fantasy-land/zero</a> <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Returns Nothing.</p>
 <div class="examples">
@@ -2083,7 +2083,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.isNothing">¶</a>
-<h4 id="Maybe.prototype.isNothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1676">Maybe#isNothing <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Boolean</a></code></h4>
+<h4 id="Maybe.prototype.isNothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1676">Maybe#isNothing</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p><code>true</code> if <code>this</code> is Nothing; <code>false</code> if <code>this</code> is a Just.</p>
 <div class="examples">
@@ -2098,7 +2098,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.isJust">¶</a>
-<h4 id="Maybe.prototype.isJust"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1688">Maybe#isJust <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Boolean</a></code></h4>
+<h4 id="Maybe.prototype.isJust"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1688">Maybe#isJust</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p><code>true</code> if <code>this</code> is a Just; <code>false</code> if <code>this</code> is Nothing.</p>
 <div class="examples">
@@ -2113,7 +2113,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.toString">¶</a>
-<h4 id="Maybe.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1700">Maybe#toString <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="Maybe.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1700">Maybe#toString</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Returns the string representation of the Maybe.</p>
 <div class="examples">
@@ -2128,7 +2128,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.inspect">¶</a>
-<h4 id="Maybe.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1715">Maybe#inspect <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="Maybe.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1715">Maybe#inspect</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Returns the string representation of the Maybe. This method is used by
 <code>util.inspect</code> and the REPL to format a Maybe for display.</p>
@@ -2145,7 +2145,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/equals">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1731">Maybe#fantasy-land/equals <span class="tight">:</span><span class="tight">:</span> Setoid a <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1731">Maybe#fantasy-land/equals</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a <span class="arrow">=&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Takes a value <code>m</code> of the same type and returns <code>true</code> if:</p>
 <ul>
@@ -2175,7 +2175,7 @@ to <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#e
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/lte">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1758">Maybe#fantasy-land/lte <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1758">Maybe#fantasy-land/lte</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Takes a value <code>m</code> of the same type and returns <code>true</code> if:</p>
 <ul>
@@ -2209,7 +2209,7 @@ or equal to the value of <code>m</code> according to <a href="https://github.com
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/concat">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1787">Maybe#fantasy-land/concat <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1787">Maybe#fantasy-land/concat</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> a <span class="arrow">=&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Returns the result of concatenating two Maybe values of the same type.
 <code>a</code> must have a <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#semigroup">Semigroup</a>.</p>
@@ -2239,7 +2239,7 @@ the given Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/map">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1820">Maybe#fantasy-land/map <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1820">Maybe#fantasy-land/map</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is Nothing; otherwise
 it returns a Just whose value is the result of applying the function
@@ -2256,7 +2256,7 @@ to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/ap">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1837">Maybe#fantasy-land/ap <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1837">Maybe#fantasy-land/ap</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="#MaybeType">Maybe</a> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a Maybe and returns Nothing unless <code>this</code> is a Just <em>and</em> the
 argument is a Just, in which case it returns a Just whose value is
@@ -2281,7 +2281,7 @@ the result of applying the given Just&#39;s value to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/chain">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1860">Maybe#fantasy-land/chain <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1860">Maybe#fantasy-land/chain</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is Nothing; otherwise
 it returns the result of applying the function to this Just&#39;s value.</p>
@@ -2301,7 +2301,7 @@ it returns the result of applying the function to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/alt">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1879">Maybe#fantasy-land/alt <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1879">Maybe#fantasy-land/alt</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Chooses between <code>this</code> and the other Maybe provided as an argument.
 Returns <code>this</code> if <code>this</code> is a Just; the other Maybe otherwise.</p>
@@ -2325,7 +2325,7 @@ Returns <code>this</code> if <code>this</code> is a Just; the other Maybe otherw
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/reduce">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1901">Maybe#fantasy-land/reduce <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1901">Maybe#fantasy-land/reduce</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>Takes a function and an initial value of any type, and returns:</p>
 <ul>
@@ -2347,7 +2347,7 @@ Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/traverse">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1921">Maybe#fantasy-land/traverse <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> (TypeRep f, a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (Maybe b)</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1921">Maybe#fantasy-land/traverse</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f <span class="arrow">=&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> (<a href="#type-representatives">TypeRep</a> f, a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (<a href="#MaybeType">Maybe</a> b)</code></h4>
 
 <p>Takes the type representative of some <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#applicative">Applicative</a> and a function
 which returns a value of that Applicative, and returns:</p>
@@ -2371,7 +2371,7 @@ first function to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/extend">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1943">Maybe#fantasy-land/extend <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1943">Maybe#fantasy-land/extend</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> (<a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is Nothing; otherwise
 it returns a Just whose value is the result of applying the function
@@ -2388,7 +2388,7 @@ to <code>this</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#isNothing">¶</a>
-<h4 id="isNothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1960">isNothing <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="isNothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1960">isNothing</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Maybe is Nothing; <code>false</code> if it is a Just.</p>
 <div class="examples">
@@ -2403,7 +2403,7 @@ to <code>this</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#isJust">¶</a>
-<h4 id="isJust"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1976">isJust <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="isJust"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1976">isJust</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Maybe is a Just; <code>false</code> if it is Nothing.</p>
 <div class="examples">
@@ -2418,7 +2418,7 @@ to <code>this</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#fromMaybe">¶</a>
-<h4 id="fromMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1992">fromMaybe <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="fromMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L1992">fromMaybe</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p>Takes a default value and a Maybe, and returns the Maybe&#39;s value
 if the Maybe is a Just; the default value otherwise.</p>
@@ -2436,7 +2436,7 @@ if the Maybe is a Just; the default value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#fromMaybe_">¶</a>
-<h4 id="fromMaybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2012">fromMaybe_ <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="fromMaybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2012">fromMaybe_</a> <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p>Variant of <a href="#fromMaybe"><code>fromMaybe</code></a> which takes a thunk so the default
 value is only computed if required.</p>
@@ -2456,7 +2456,7 @@ value is only computed if required.</p>
 </div>
 
 <a class="pilcrow h4" href="#maybeToNullable">¶</a>
-<h4 id="maybeToNullable"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2031">maybeToNullable <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Nullable a</a></code></h4>
+<h4 id="maybeToNullable"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2031">maybeToNullable</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Nullable">Nullable</a> a</code></h4>
 
 <p>Returns the given Maybe&#39;s value if the Maybe is a Just; <code>null</code> otherwise.
 <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Nullable">Nullable</a> is defined in <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0">sanctuary-def</a>.</p>
@@ -2473,7 +2473,7 @@ value is only computed if required.</p>
 </div>
 
 <a class="pilcrow h4" href="#toMaybe">¶</a>
-<h4 id="toMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2051">toMaybe <span class="tight">:</span><span class="tight">:</span> a? <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="toMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2051">toMaybe</a> <span class="tight">:</span><span class="tight">:</span> a? <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a value and returns Nothing if the value is <code>null</code> or <code>undefined</code>;
 Just the value otherwise.</p>
@@ -2489,7 +2489,7 @@ Just the value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#maybe">¶</a>
-<h4 id="maybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2068">maybe <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="maybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2068">maybe</a> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>Takes a value of any type, a function, and a Maybe. If the Maybe is
 a Just, the return value is the result of applying the function to
@@ -2507,7 +2507,7 @@ the Just&#39;s value. Otherwise, the first argument is returned.</p>
 </div>
 
 <a class="pilcrow h4" href="#maybe_">¶</a>
-<h4 id="maybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2088">maybe_ <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="maybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2088">maybe_</a> <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>Variant of <a href="#maybe"><code>maybe</code></a> which takes a thunk so the default value
 is only computed if required.</p>
@@ -2527,7 +2527,7 @@ is only computed if required.</p>
 </div>
 
 <a class="pilcrow h4" href="#justs">¶</a>
-<h4 id="justs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2107">justs <span class="tight">:</span><span class="tight">:</span> Array (Maybe a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a</a></code></h4>
+<h4 id="justs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2107">justs</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> (<a href="#MaybeType">Maybe</a> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> a</code></h4>
 
 <p>Takes an array of Maybes and returns an array containing each Just&#39;s
 value. Equivalent to Haskell&#39;s <code>catMaybes</code> function.</p>
@@ -2540,7 +2540,7 @@ value. Equivalent to Haskell&#39;s <code>catMaybes</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#mapMaybe">¶</a>
-<h4 id="mapMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2126">mapMaybe <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array b</a></code></h4>
+<h4 id="mapMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2126">mapMaybe</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> b</code></h4>
 
 <p>Takes a function and an array, applies the function to each element of
 the array, and returns an array of &quot;successful&quot; results. If the result of
@@ -2556,7 +2556,7 @@ the output array.</p>
 </div>
 
 <a class="pilcrow h4" href="#encase">¶</a>
-<h4 id="encase"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2146">encase <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</a></code></h4>
+<h4 id="encase"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2146">encase</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a unary function <code>f</code> which may throw and a value <code>x</code> of any type,
 and applies <code>f</code> to <code>x</code> inside a <code>try</code> block. If an exception is caught,
@@ -2575,27 +2575,27 @@ result of applying <code>f</code> to <code>x</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#encase2">¶</a>
-<h4 id="encase2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2171">encase2 <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe c</a></code></h4>
+<h4 id="encase2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2171">encase2</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> c</code></h4>
 
 <p>Binary version of <a href="#encase"><code>encase</code></a>.</p>
 <p>See also <a href="#encase2_"><code>encase2_</code></a>.</p>
 <a class="pilcrow h4" href="#encase2_">¶</a>
-<h4 id="encase2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2181">encase2_ <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe c</a></code></h4>
+<h4 id="encase2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2181">encase2_</a> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> c</code></h4>
 
 <p>Variant of <a href="#encase2"><code>encase2</code></a> which takes an uncurried binary
 function.</p>
 <a class="pilcrow h4" href="#encase3">¶</a>
-<h4 id="encase3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2195">encase3 <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe d</a></code></h4>
+<h4 id="encase3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2195">encase3</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> d</code></h4>
 
 <p>Ternary version of <a href="#encase"><code>encase</code></a>.</p>
 <p>See also <a href="#encase3_"><code>encase3_</code></a>.</p>
 <a class="pilcrow h4" href="#encase3_">¶</a>
-<h4 id="encase3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2206">encase3_ <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe d</a></code></h4>
+<h4 id="encase3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2206">encase3_</a> <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> d</code></h4>
 
 <p>Variant of <a href="#encase3"><code>encase3</code></a> which takes an uncurried ternary
 function.</p>
 <a class="pilcrow h4" href="#maybeToEither">¶</a>
-<h4 id="maybeToEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2223">maybeToEither <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</a></code></h4>
+<h4 id="maybeToEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2223">maybeToEither</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Converts a Maybe to an Either. Nothing becomes a Left (containing the
 first argument); a Just becomes a Right.</p>
@@ -2619,15 +2619,15 @@ value is of type <code>b</code>.</p>
 <p>The Either type satisfies the <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#setoid">Setoid</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#semigroup">Semigroup</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#monad">Monad</a>,
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#alt">Alt</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#traversable">Traversable</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#extend">Extend</a>, and <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#bifunctor">Bifunctor</a> specifications.</p>
 <a class="pilcrow h4" href="#EitherType">¶</a>
-<h4 id="EitherType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2252">EitherType <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Type</a></code></h4>
+<h4 id="EitherType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2252">EitherType</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Type">Type</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Type">Type</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Type">Type</a></code></h4>
 
 <p>A <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#BinaryType"><code>BinaryType</code></a> for use with <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0">sanctuary-def</a>.</p>
 <a class="pilcrow h4" href="#Either">¶</a>
-<h4 id="Either"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2257">Either <span class="tight">:</span><span class="tight">:</span> TypeRep Either</a></code></h4>
+<h4 id="Either"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2257">Either</a> <span class="tight">:</span><span class="tight">:</span> <a href="#type-representatives">TypeRep</a> <a href="#EitherType">Either</a></code></h4>
 
 <p>The <a href="#type-representatives">type representative</a> for the Either type.</p>
 <a class="pilcrow h4" href="#Left">¶</a>
-<h4 id="Left"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2285">Left <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</a></code></h4>
+<h4 id="Left"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2285">Left</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Takes a value of any type and returns a Left with the given value.</p>
 <div class="examples">
@@ -2638,7 +2638,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Right">¶</a>
-<h4 id="Right"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2298">Right <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</a></code></h4>
+<h4 id="Right"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2298">Right</a> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Takes a value of any type and returns a Right with the given value.</p>
 <div class="examples">
@@ -2649,11 +2649,11 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.@@type">¶</a>
-<h4 id="Either.@@type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2311">Either.@@type <span class="tight">:</span><span class="tight">:</span> String</a></code></h4>
+<h4 id="Either.@@type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2311">Either.@@type</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Either type identifier, <code>&#39;sanctuary/Either&#39;</code>.</p>
 <a class="pilcrow h4" href="#Either.fantasy-land/of">¶</a>
-<h4 id="Either.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2316">Either.fantasy-land/of <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</a></code></h4>
+<h4 id="Either.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2316">Either.fantasy-land/of</a> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Takes a value of any type and returns a Right with the given value.</p>
 <div class="examples">
@@ -2664,7 +2664,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.isLeft">¶</a>
-<h4 id="Either.prototype.isLeft"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2326">Either#isLeft <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Boolean</a></code></h4>
+<h4 id="Either.prototype.isLeft"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2326">Either#isLeft</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p><code>true</code> if <code>this</code> is a Left; <code>false</code> if <code>this</code> is a Right.</p>
 <div class="examples">
@@ -2679,7 +2679,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.isRight">¶</a>
-<h4 id="Either.prototype.isRight"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2338">Either#isRight <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Boolean</a></code></h4>
+<h4 id="Either.prototype.isRight"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2338">Either#isRight</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p><code>true</code> if <code>this</code> is a Right; <code>false</code> if <code>this</code> is a Left.</p>
 <div class="examples">
@@ -2694,7 +2694,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.toString">¶</a>
-<h4 id="Either.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2350">Either#toString <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="Either.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2350">Either#toString</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Returns the string representation of the Either.</p>
 <div class="examples">
@@ -2709,7 +2709,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.inspect">¶</a>
-<h4 id="Either.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2366">Either#inspect <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="Either.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2366">Either#inspect</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Returns the string representation of the Either. This method is used by
 <code>util.inspect</code> and the REPL to format a Either for display.</p>
@@ -2726,7 +2726,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/equals">¶</a>
-<h4 id="Either.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2382">Either#fantasy-land/equals <span class="tight">:</span><span class="tight">:</span> (Setoid a, Setoid b) <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2382">Either#fantasy-land/equals</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> b) <span class="arrow">=&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Takes a value <code>e</code> of the same type and returns <code>true</code> if:</p>
 <ul>
@@ -2745,7 +2745,7 @@ equal according to <a href="https://github.com/sanctuary-js/sanctuary-type-class
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/lte">¶</a>
-<h4 id="Either.prototype.fantasy-land/lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2400">Either#fantasy-land/lte <span class="tight">:</span><span class="tight">:</span> (Ord a, Ord b) <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2400">Either#fantasy-land/lte</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> b) <span class="arrow">=&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Takes a value <code>e</code> of the same type and returns <code>true</code> if:</p>
 <ul>
@@ -2775,7 +2775,7 @@ is less than or equal to the value of <code>e</code> according to <a href="https
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/concat">¶</a>
-<h4 id="Either.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2428">Either#fantasy-land/concat <span class="tight">:</span><span class="tight">:</span> (Semigroup a, Semigroup b) <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2428">Either#fantasy-land/concat</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> b) <span class="arrow">=&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Returns the result of concatenating two Either values of the same type.
 <code>a</code> must have a <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#semigroup">Semigroup</a>, as must <code>b</code>.</p>
@@ -2806,7 +2806,7 @@ the given Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/map">¶</a>
-<h4 id="Either.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2462">Either#fantasy-land/map <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a c</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2462">Either#fantasy-land/map</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a c</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is a Left; otherwise it
 returns a Right whose value is the result of applying the function to
@@ -2824,7 +2824,7 @@ this Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/bimap">¶</a>
-<h4 id="Either.prototype.fantasy-land/bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2481">Either#fantasy-land/bimap <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c, b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either c d</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2481">Either#fantasy-land/bimap</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c, b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> c d</code></h4>
 
 <p>Takes two functions and returns:</p>
 <ul>
@@ -2849,7 +2849,7 @@ left side as well as the right side.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/ap">¶</a>
-<h4 id="Either.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2505">Either#fantasy-land/ap <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a c</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2505">Either#fantasy-land/ap</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="#EitherType">Either</a> a (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a c</code></h4>
 
 <p>Takes an Either and returns a Left unless <code>this</code> is a Right <em>and</em> the
 argument is a Right, in which case it returns a Right whose value is
@@ -2874,7 +2874,7 @@ the result of applying the given Right&#39;s value to this Right&#39;s value.</p
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/chain">¶</a>
-<h4 id="Either.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2528">Either#fantasy-land/chain <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a c</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2528">Either#fantasy-land/chain</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a c</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is a Left; otherwise
 it returns the result of applying the function to this Right&#39;s value.</p>
@@ -2898,7 +2898,7 @@ it returns the result of applying the function to this Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/alt">¶</a>
-<h4 id="Either.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2552">Either#fantasy-land/alt <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2552">Either#fantasy-land/alt</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Chooses between <code>this</code> and the other Either provided as an argument.
 Returns <code>this</code> if <code>this</code> is a Right; the other Either otherwise.</p>
@@ -2922,7 +2922,7 @@ Returns <code>this</code> if <code>this</code> is a Right; the other Either othe
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/reduce">¶</a>
-<h4 id="Either.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2574">Either#fantasy-land/reduce <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> ((c, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2574">Either#fantasy-land/reduce</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> ((c, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
 
 <p>Takes a function and an initial value of any type, and returns:</p>
 <ul>
@@ -2944,7 +2944,7 @@ Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/traverse">¶</a>
-<h4 id="Either.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2594">Either#fantasy-land/traverse <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> (TypeRep f, b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (Either a c)</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2594">Either#fantasy-land/traverse</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f <span class="arrow">=&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> (<a href="#type-representatives">TypeRep</a> f, b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (<a href="#EitherType">Either</a> a c)</code></h4>
 
 <p>Takes the type representative of some <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#applicative">Applicative</a> and a function
 which returns a value of that Applicative, and returns:</p>
@@ -2968,7 +2968,7 @@ the first function to this Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/extend">¶</a>
-<h4 id="Either.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2616">Either#fantasy-land/extend <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a c</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2616">Either#fantasy-land/extend</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> (<a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a c</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is a Left; otherwise it
 returns a Right whose value is the result of applying the function to
@@ -2985,7 +2985,7 @@ returns a Right whose value is the result of applying the function to
 </div>
 
 <a class="pilcrow h4" href="#isLeft">¶</a>
-<h4 id="isLeft"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2633">isLeft <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="isLeft"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2633">isLeft</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Either is a Left; <code>false</code> if it is a Right.</p>
 <div class="examples">
@@ -3000,7 +3000,7 @@ returns a Right whose value is the result of applying the function to
 </div>
 
 <a class="pilcrow h4" href="#isRight">¶</a>
-<h4 id="isRight"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2649">isRight <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="isRight"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2649">isRight</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Either is a Right; <code>false</code> if it is a Left.</p>
 <div class="examples">
@@ -3015,7 +3015,7 @@ returns a Right whose value is the result of applying the function to
 </div>
 
 <a class="pilcrow h4" href="#fromEither">¶</a>
-<h4 id="fromEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2665">fromEither <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="fromEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2665">fromEither</a> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>Takes a default value and an Either, and returns the Right value
 if the Either is a Right; the default value otherwise.</p>
@@ -3031,7 +3031,7 @@ if the Either is a Right; the default value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#toEither">¶</a>
-<h4 id="toEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2682">toEither <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b? <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</a></code></h4>
+<h4 id="toEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2682">toEither</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b? <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Converts an arbitrary value to an Either: a Left if the value is <code>null</code>
 or <code>undefined</code>; a Right otherwise. The first argument specifies the
@@ -3056,7 +3056,7 @@ value of the Left in the &quot;failure&quot; case.</p>
 </div>
 
 <a class="pilcrow h4" href="#either">¶</a>
-<h4 id="either"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2706">either <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</a></code></h4>
+<h4 id="either"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2706">either</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
 
 <p>Takes two functions and an Either, and returns the result of
 applying the first function to the Left&#39;s value, if the Either
@@ -3074,7 +3074,7 @@ Right&#39;s value, if the Either is a Right.</p>
 </div>
 
 <a class="pilcrow h4" href="#lefts">¶</a>
-<h4 id="lefts"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2725">lefts <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a</a></code></h4>
+<h4 id="lefts"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2725">lefts</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> (<a href="#EitherType">Either</a> a b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> a</code></h4>
 
 <p>Takes an array of Eithers and returns an array containing each Left&#39;s
 value.</p>
@@ -3087,7 +3087,7 @@ value.</p>
 </div>
 
 <a class="pilcrow h4" href="#rights">¶</a>
-<h4 id="rights"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2744">rights <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array b</a></code></h4>
+<h4 id="rights"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2744">rights</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> (<a href="#EitherType">Either</a> a b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> b</code></h4>
 
 <p>Takes an array of Eithers and returns an array containing each Right&#39;s
 value.</p>
@@ -3100,7 +3100,7 @@ value.</p>
 </div>
 
 <a class="pilcrow h4" href="#tagBy">¶</a>
-<h4 id="tagBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2763">tagBy <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a a</a></code></h4>
+<h4 id="tagBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2763">tagBy</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a a</code></h4>
 
 <p>Takes a predicate and a value, and returns a Right of the value if it
 satisfies the predicate; a Left of the value otherwise.</p>
@@ -3116,7 +3116,7 @@ satisfies the predicate; a Left of the value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#encaseEither">¶</a>
-<h4 id="encaseEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2780">encaseEither <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either l r</a></code></h4>
+<h4 id="encaseEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2780">encaseEither</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Error">Error</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> l r</code></h4>
 
 <p>Takes two unary functions, <code>f</code> and <code>g</code>, the second of which may throw,
 and a value <code>x</code> of any type. Applies <code>g</code> to <code>x</code> inside a <code>try</code> block.
@@ -3140,27 +3140,27 @@ value is a Right containing the result of applying <code>g</code> to <code>x</co
 </div>
 
 <a class="pilcrow h4" href="#encaseEither2">¶</a>
-<h4 id="encaseEither2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2813">encaseEither2 <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either l r</a></code></h4>
+<h4 id="encaseEither2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2813">encaseEither2</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Error">Error</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> l r</code></h4>
 
 <p>Binary version of <a href="#encaseEither"><code>encaseEither</code></a>.</p>
 <p>See also <a href="#encaseEither2_"><code>encaseEither2_</code></a>.</p>
 <a class="pilcrow h4" href="#encaseEither2_">¶</a>
-<h4 id="encaseEither2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2827">encaseEither2_ <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either l r</a></code></h4>
+<h4 id="encaseEither2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2827">encaseEither2_</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Error">Error</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> l r</code></h4>
 
 <p>Variant of <a href="#encaseEither2"><code>encaseEither2</code></a> which takes an uncurried
 binary function.</p>
 <a class="pilcrow h4" href="#encaseEither3">¶</a>
-<h4 id="encaseEither3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2844">encaseEither3 <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either l r</a></code></h4>
+<h4 id="encaseEither3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2844">encaseEither3</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Error">Error</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> l r</code></h4>
 
 <p>Ternary version of <a href="#encaseEither"><code>encaseEither</code></a>.</p>
 <p>See also <a href="#encaseEither3_"><code>encaseEither3_</code></a>.</p>
 <a class="pilcrow h4" href="#encaseEither3_">¶</a>
-<h4 id="encaseEither3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2858">encaseEither3_ <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either l r</a></code></h4>
+<h4 id="encaseEither3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2858">encaseEither3_</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Error">Error</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> l r</code></h4>
 
 <p>Variant of <a href="#encaseEither3"><code>encaseEither3</code></a> which takes an uncurried
 ternary function.</p>
 <a class="pilcrow h4" href="#eitherToMaybe">¶</a>
-<h4 id="eitherToMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2875">eitherToMaybe <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</a></code></h4>
+<h4 id="eitherToMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2875">eitherToMaybe</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Converts an Either to a Maybe. A Left becomes Nothing; a Right becomes
 a Just.</p>
@@ -3179,7 +3179,7 @@ a Just.</p>
 <a class="pilcrow h3" href="#logic">¶</a>
 <h3 id="logic">Logic</h3>
 <a class="pilcrow h4" href="#and">¶</a>
-<h4 id="and"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2897">and <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="and"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2897">and</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Boolean &quot;and&quot;.</p>
 <div class="examples">
@@ -3202,7 +3202,7 @@ a Just.</p>
 </div>
 
 <a class="pilcrow h4" href="#or">¶</a>
-<h4 id="or"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2919">or <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="or"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2919">or</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Boolean &quot;or&quot;.</p>
 <div class="examples">
@@ -3225,7 +3225,7 @@ a Just.</p>
 </div>
 
 <a class="pilcrow h4" href="#not">¶</a>
-<h4 id="not"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2941">not <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="not"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2941">not</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Boolean &quot;not&quot;.</p>
 <p>See also <a href="#complement"><code>complement</code></a>.</p>
@@ -3241,7 +3241,7 @@ a Just.</p>
 </div>
 
 <a class="pilcrow h4" href="#complement">¶</a>
-<h4 id="complement"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2959">complement <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="complement"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2959">complement</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Takes a unary predicate and a value of any type, and returns the logical
 negation of applying the predicate to the value.</p>
@@ -3258,7 +3258,7 @@ negation of applying the predicate to the value.</p>
 </div>
 
 <a class="pilcrow h4" href="#ifElse">¶</a>
-<h4 id="ifElse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2978">ifElse <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="ifElse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L2978">ifElse</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>Takes a unary predicate, a unary &quot;if&quot; function, a unary &quot;else&quot;
 function, and a value of any type, and returns the result of
@@ -3278,7 +3278,7 @@ value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#when">¶</a>
-<h4 id="when"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3000">when <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="when"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3000">when</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p>Takes a unary predicate, a unary function, and a value of any type, and
 returns the result of applying the function to the value if the value
@@ -3296,7 +3296,7 @@ satisfies the predicate; the value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#unless">¶</a>
-<h4 id="unless"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3020">unless <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</a></code></h4>
+<h4 id="unless"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3020">unless</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
 
 <p>Takes a unary predicate, a unary function, and a value of any type, and
 returns the result of applying the function to the value if the value
@@ -3314,7 +3314,7 @@ does not satisfy the predicate; the value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#allPass">¶</a>
-<h4 id="allPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3040">allPass <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="allPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3040">allPass</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Takes an array of unary predicates and a value of any type
 and returns <code>true</code> if all the predicates pass; <code>false</code> otherwise.
@@ -3332,7 +3332,7 @@ first failed predicate.</p>
 </div>
 
 <a class="pilcrow h4" href="#anyPass">¶</a>
-<h4 id="anyPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3059">anyPass <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="anyPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3059">anyPass</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Takes an array of unary predicates and a value of any type
 and returns <code>true</code> if any of the predicates pass; <code>false</code> otherwise.
@@ -3372,7 +3372,7 @@ replaced with the latter:</p>
 </code></pre><p>It&#39;s then apparent that the first argument needn&#39;t be a single-character
 string; the correspondence between arrays and strings does not hold.</p>
 <a class="pilcrow h4" href="#slice">¶</a>
-<h4 id="slice"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3110">slice <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="slice"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3110">slice</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Returns Just a list containing the elements from the supplied list
 from a beginning index (inclusive) to an end index (exclusive).
@@ -3404,7 +3404,7 @@ the list.</p>
 </div>
 
 <a class="pilcrow h4" href="#at">¶</a>
-<h4 id="at"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3147">at <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="at"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3147">at</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes an index and a list and returns Just the element of the list at
 the index if the index is within the list&#39;s bounds; Nothing otherwise.
@@ -3425,7 +3425,7 @@ A negative index represents an offset from the length of the list.</p>
 </div>
 
 <a class="pilcrow h4" href="#head">¶</a>
-<h4 id="head"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3168">head <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="head"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3168">head</a> <span class="tight">:</span><span class="tight">:</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a list and returns Just the first element of the list if the
 list contains at least one element; Nothing if the list is empty.</p>
@@ -3441,7 +3441,7 @@ list contains at least one element; Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#last">¶</a>
-<h4 id="last"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3185">last <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="last"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3185">last</a> <span class="tight">:</span><span class="tight">:</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a list and returns Just the last element of the list if the
 list contains at least one element; Nothing if the list is empty.</p>
@@ -3457,7 +3457,7 @@ list contains at least one element; Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#tail">¶</a>
-<h4 id="tail"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3202">tail <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="tail"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3202">tail</a> <span class="tight">:</span><span class="tight">:</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Takes a list and returns Just a list containing all but the first
 of the list&#39;s elements if the list contains at least one element;
@@ -3474,7 +3474,7 @@ Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#init">¶</a>
-<h4 id="init"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3220">init <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="init"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3220">init</a> <span class="tight">:</span><span class="tight">:</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Takes a list and returns Just a list containing all but the last
 of the list&#39;s elements if the list contains at least one element;
@@ -3491,7 +3491,7 @@ Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#take">¶</a>
-<h4 id="take"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3238">take <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="take"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3238">take</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Returns Just the first N elements of the given collection if N is
 greater than or equal to zero and less than or equal to the length
@@ -3512,7 +3512,7 @@ of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#takeLast">¶</a>
-<h4 id="takeLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3259">takeLast <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="takeLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3259">takeLast</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Returns Just the last N elements of the given collection if N is
 greater than or equal to zero and less than or equal to the length
@@ -3533,7 +3533,7 @@ of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#drop">¶</a>
-<h4 id="drop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3281">drop <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="drop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3281">drop</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Returns Just all but the first N elements of the given collection
 if N is greater than or equal to zero and less than or equal to the
@@ -3554,7 +3554,7 @@ length of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#dropLast">¶</a>
-<h4 id="dropLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3302">dropLast <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</a></code></h4>
+<h4 id="dropLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3302">dropLast</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Returns Just all but the last N elements of the given collection
 if N is greater than or equal to zero and less than or equal to the
@@ -3575,7 +3575,7 @@ length of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#reverse">¶</a>
-<h4 id="reverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3324">reverse <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a</a></code></h4>
+<h4 id="reverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3324">reverse</a> <span class="tight">:</span><span class="tight">:</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a</code></h4>
 
 <p>Returns the elements of the given list in reverse order.</p>
 <div class="examples">
@@ -3590,7 +3590,7 @@ length of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#indexOf">¶</a>
-<h4 id="indexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3341">indexOf <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe Integer</a></code></h4>
+<h4 id="indexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3341">indexOf</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a></code></h4>
 
 <p>Takes a value of any type and a list, and returns Just the index
 of the first occurrence of the value in the list, if applicable;
@@ -3615,7 +3615,7 @@ Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#lastIndexOf">¶</a>
-<h4 id="lastIndexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3366">lastIndexOf <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe Integer</a></code></h4>
+<h4 id="lastIndexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3366">lastIndexOf</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a></code></h4>
 
 <p>Takes a value of any type and a list, and returns Just the index
 of the last occurrence of the value in the list, if applicable;
@@ -3642,7 +3642,7 @@ Nothing otherwise.</p>
 <a class="pilcrow h3" href="#array">¶</a>
 <h3 id="array">Array</h3>
 <a class="pilcrow h4" href="#append">¶</a>
-<h4 id="append"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3394">append <span class="tight">:</span><span class="tight">:</span> (Applicative f, Semigroup (f a)) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</a></code></h4>
+<h4 id="append"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3394">append</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> (f a)) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
 
 <p>Returns the result of appending the first argument to the second.</p>
 <p>See also <a href="#prepend"><code>prepend</code></a>.</p>
@@ -3662,7 +3662,7 @@ Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#prepend">¶</a>
-<h4 id="prepend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3419">prepend <span class="tight">:</span><span class="tight">:</span> (Applicative f, Semigroup (f a)) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</a></code></h4>
+<h4 id="prepend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3419">prepend</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> (f a)) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
 
 <p>Returns the result of prepending the first argument to the second.</p>
 <p>See also <a href="#append"><code>append</code></a>.</p>
@@ -3682,7 +3682,7 @@ Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#joinWith">¶</a>
-<h4 id="joinWith"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3444">joinWith <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="joinWith"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3444">joinWith</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Joins the strings of the second argument separated by the first argument.</p>
 <p>Properties:</p>
@@ -3698,7 +3698,7 @@ Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#elem">¶</a>
-<h4 id="elem"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3464">elem <span class="tight">:</span><span class="tight">:</span> (Setoid a, Foldable f) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="elem"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3464">elem</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Takes a value and a structure and returns <code>true</code> if the value is an
 element of the structure; <code>false</code> otherwise.</p>
@@ -3735,7 +3735,7 @@ element of the structure; <code>false</code> otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#find">¶</a>
-<h4 id="find"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3499">find <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</a></code></h4>
+<h4 id="find"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3499">find</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a predicate and a structure and returns Just the leftmost element
 of the structure which satisfies the predicate; Nothing if there is no
@@ -3753,7 +3753,7 @@ such element.</p>
 </div>
 
 <a class="pilcrow h4" href="#pluck">¶</a>
-<h4 id="pluck"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3523">pluck <span class="tight">:</span><span class="tight">:</span> (Accessible a, Functor f) <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</a></code></h4>
+<h4 id="pluck"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3523">pluck</a> <span class="tight">:</span><span class="tight">:</span> (<a href="#accessible-pseudotype">Accessible</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Functor">Functor</a> f) <span class="arrow">=&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></h4>
 
 <p>Combines <a href="#map"><code>map</code></a> and <a href="#prop"><code>prop</code></a>. <code>pluck(k, xs)</code> is equivalent
 to <code>map(prop(k), xs)</code>.</p>
@@ -3769,7 +3769,7 @@ to <code>map(prop(k), xs)</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#unfoldr">¶</a>
-<h4 id="unfoldr"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3548">unfoldr <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (Pair a b)) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a</a></code></h4>
+<h4 id="unfoldr"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3548">unfoldr</a> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Pair">Pair</a> a b)) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> a</code></h4>
 
 <p>Takes a function and a seed value, and returns an array generated by
 applying the function repeatedly. The array is initially empty. The
@@ -3790,7 +3790,7 @@ the array and the function is applied to the second element.</p>
 </div>
 
 <a class="pilcrow h4" href="#range">¶</a>
-<h4 id="range"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3572">range <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array Integer</a></code></h4>
+<h4 id="range"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3572">range</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a></code></h4>
 
 <p>Returns an array of consecutive integers starting with the first argument
 and ending with the second argument minus one. Returns <code>[]</code> if the second
@@ -3811,7 +3811,7 @@ argument is less than or equal to the first argument.</p>
 </div>
 
 <a class="pilcrow h4" href="#groupBy">¶</a>
-<h4 id="groupBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3596">groupBy <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array (Array a)</a></code></h4>
+<h4 id="groupBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3596">groupBy</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> a)</code></h4>
 
 <p>Splits its array argument into an array of arrays of equal,
 adjacent elements. Equality is determined by the function
@@ -3836,11 +3836,11 @@ for functions that aren&#39;t reflexive, transitive, and symmetric
 </div>
 
 <a class="pilcrow h4" href="#groupBy_">¶</a>
-<h4 id="groupBy_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3627">groupBy_ <span class="tight">:</span><span class="tight">:</span> ((a, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array (Array a)</a></code></h4>
+<h4 id="groupBy_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3627">groupBy_</a> <span class="tight">:</span><span class="tight">:</span> ((a, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> a)</code></h4>
 
 <p>Variant of <a href="#groupBy"><code>groupBy</code></a> which takes an uncurried function.</p>
 <a class="pilcrow h4" href="#sort">¶</a>
-<h4 id="sort"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3647">sort <span class="tight">:</span><span class="tight">:</span> (Ord a, Applicative m, Foldable m, Monoid (m a)) <span class="arrow">=&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</a></code></h4>
+<h4 id="sort"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3647">sort</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> (m a)) <span class="arrow">=&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></h4>
 
 <p>Performs a <a href="https://en.wikipedia.org/wiki/Sorting_algorithm#Stability">stable sort</a> of the elements of the given structure, using
 <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a> for comparisons.</p>
@@ -3861,7 +3861,7 @@ for functions that aren&#39;t reflexive, transitive, and symmetric
 </div>
 
 <a class="pilcrow h4" href="#sortBy">¶</a>
-<h4 id="sortBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3674">sortBy <span class="tight">:</span><span class="tight">:</span> (Ord b, Applicative m, Foldable m, Monoid (m a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</a></code></h4>
+<h4 id="sortBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3674">sortBy</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> b, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> (m a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></h4>
 
 <p>Performs a <a href="https://en.wikipedia.org/wiki/Sorting_algorithm#Stability">stable sort</a> of the elements of the given structure, using
 <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a> to compare the values produced by applying the given function
@@ -3885,7 +3885,7 @@ to each element of the structure.</p>
 <a class="pilcrow h3" href="#object">¶</a>
 <h3 id="object">Object</h3>
 <a class="pilcrow h4" href="#prop">¶</a>
-<h4 id="prop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3737">prop <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="prop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3737">prop</a> <span class="tight">:</span><span class="tight">:</span> <a href="#accessible-pseudotype">Accessible</a> a <span class="arrow">=&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>Takes a property name and an object with known properties and returns
 the value of the specified property. If for some reason the object
@@ -3900,7 +3900,7 @@ lacks the specified property, a type error is thrown.</p>
 </div>
 
 <a class="pilcrow h4" href="#props">¶</a>
-<h4 id="props"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3758">props <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</a></code></h4>
+<h4 id="props"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3758">props</a> <span class="tight">:</span><span class="tight">:</span> <a href="#accessible-pseudotype">Accessible</a> a <span class="arrow">=&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
 
 <p>Takes a property path (an array of property names) and an object with
 known structure and returns the value at the given path. If for some
@@ -3915,7 +3915,7 @@ instead.</p>
 </div>
 
 <a class="pilcrow h4" href="#get">¶</a>
-<h4 id="get"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3781">get <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe c</a></code></h4>
+<h4 id="get"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3781">get</a> <span class="tight">:</span><span class="tight">:</span> <a href="#accessible-pseudotype">Accessible</a> a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> c</code></h4>
 
 <p>Takes a predicate, a property name, and an object and returns Just the
 value of the specified object property if it exists and the value
@@ -3937,7 +3937,7 @@ satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#gets">¶</a>
-<h4 id="gets"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3806">gets <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe c</a></code></h4>
+<h4 id="gets"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3806">gets</a> <span class="tight">:</span><span class="tight">:</span> <a href="#accessible-pseudotype">Accessible</a> a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> c</code></h4>
 
 <p>Takes a predicate, a property path (an array of property names), and
 an object and returns Just the value at the given path if such a path
@@ -3959,7 +3959,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#keys">¶</a>
-<h4 id="keys"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3837">keys <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String</a></code></h4>
+<h4 id="keys"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3837">keys</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#StrMap">StrMap</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Returns the keys of the given string map, in arbitrary order.</p>
 <div class="examples">
@@ -3970,7 +3970,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#values">¶</a>
-<h4 id="values"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3847">values <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a</a></code></h4>
+<h4 id="values"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3847">values</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#StrMap">StrMap</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> a</code></h4>
 
 <p>Returns the values of the given string map, in arbitrary order.</p>
 <div class="examples">
@@ -3981,7 +3981,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#pairs">¶</a>
-<h4 id="pairs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3860">pairs <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array (Pair String a)</a></code></h4>
+<h4 id="pairs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3860">pairs</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#StrMap">StrMap</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Pair">Pair</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> a)</code></h4>
 
 <p>Returns the key–value pairs of the given string map, in arbitrary order.</p>
 <div class="examples">
@@ -3994,7 +3994,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 <a class="pilcrow h3" href="#number">¶</a>
 <h3 id="number">Number</h3>
 <a class="pilcrow h4" href="#negate">¶</a>
-<h4 id="negate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3876">negate <span class="tight">:</span><span class="tight">:</span> ValidNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> ValidNumber</a></code></h4>
+<h4 id="negate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3876">negate</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#ValidNumber">ValidNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#ValidNumber">ValidNumber</a></code></h4>
 
 <p>Negates its argument.</p>
 <div class="examples">
@@ -4009,7 +4009,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#add">¶</a>
-<h4 id="add"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3892">add <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="add"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3892">add</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the sum of two (finite) numbers.</p>
 <div class="examples">
@@ -4020,7 +4020,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sum">¶</a>
-<h4 id="sum"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3906">sum <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="sum"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3906">sum</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> f <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the sum of the given array of (finite) numbers.</p>
 <div class="examples">
@@ -4043,7 +4043,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sub">¶</a>
-<h4 id="sub"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3929">sub <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber)</a></code></h4>
+<h4 id="sub"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3929">sub</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a>)</code></h4>
 
 <p>Takes a finite number <code>n</code> and returns the <em>subtract <code>n</code></em> function.</p>
 <p>See also <a href="#sub_"><code>sub_</code></a>.</p>
@@ -4055,7 +4055,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sub_">¶</a>
-<h4 id="sub_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3945">sub_ <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="sub_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3945">sub_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the difference between two (finite) numbers.</p>
 <p>See also <a href="#sub"><code>sub</code></a>.</p>
@@ -4067,7 +4067,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#mult">¶</a>
-<h4 id="mult"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3961">mult <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="mult"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3961">mult</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the product of two (finite) numbers.</p>
 <div class="examples">
@@ -4078,7 +4078,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#product">¶</a>
-<h4 id="product"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3975">product <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="product"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L3975">product</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> f <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the product of the given array of (finite) numbers.</p>
 <div class="examples">
@@ -4101,7 +4101,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#div">¶</a>
-<h4 id="div"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4001">div <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> NonZeroFiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</a></code></h4>
+<h4 id="div"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4001">div</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#NonZeroFiniteNumber">NonZeroFiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the result of dividing its first argument (a finite number) by
 its second argument (a non-zero finite number).</p>
@@ -4113,7 +4113,7 @@ its second argument (a non-zero finite number).</p>
 </div>
 
 <a class="pilcrow h4" href="#mean">¶</a>
-<h4 id="mean"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4016">mean <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe FiniteNumber</a></code></h4>
+<h4 id="mean"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4016">mean</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> f <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the mean of the given array of (finite) numbers.</p>
 <div class="examples">
@@ -4138,7 +4138,7 @@ its second argument (a non-zero finite number).</p>
 <a class="pilcrow h3" href="#integer">¶</a>
 <h3 id="integer">Integer</h3>
 <a class="pilcrow h4" href="#even">¶</a>
-<h4 id="even"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4053">even <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="even"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4053">even</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given integer is even; <code>false</code> if it is odd.</p>
 <div class="examples">
@@ -4153,7 +4153,7 @@ its second argument (a non-zero finite number).</p>
 </div>
 
 <a class="pilcrow h4" href="#odd">¶</a>
-<h4 id="odd"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4069">odd <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="odd"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4069">odd</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given integer is odd; <code>false</code> if it is even.</p>
 <div class="examples">
@@ -4170,7 +4170,7 @@ its second argument (a non-zero finite number).</p>
 <a class="pilcrow h3" href="#parse">¶</a>
 <h3 id="parse">Parse</h3>
 <a class="pilcrow h4" href="#parseDate">¶</a>
-<h4 id="parseDate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4087">parseDate <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe Date</a></code></h4>
+<h4 id="parseDate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4087">parseDate</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Date">Date</a></code></h4>
 
 <p>Takes a string and returns Just the date represented by the string
 if it does in fact represent a date; Nothing otherwise.</p>
@@ -4186,7 +4186,7 @@ if it does in fact represent a date; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#parseFloat">¶</a>
-<h4 id="parseFloat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4139">parseFloat <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe Number</a></code></h4>
+<h4 id="parseFloat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4139">parseFloat</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Number">Number</a></code></h4>
 
 <p>Takes a string and returns Just the number represented by the string
 if it does in fact represent a number; Nothing otherwise.</p>
@@ -4202,7 +4202,7 @@ if it does in fact represent a number; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#parseInt">¶</a>
-<h4 id="parseInt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4157">parseInt <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe Integer</a></code></h4>
+<h4 id="parseInt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4157">parseInt</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Integer">Integer</a></code></h4>
 
 <p>Takes a radix (an integer between 2 and 36 inclusive) and a string,
 and returns Just the number represented by the string if it does in
@@ -4227,7 +4227,7 @@ characters are members of the character set specified by the radix.</p>
 </div>
 
 <a class="pilcrow h4" href="#parseJson">¶</a>
-<h4 id="parseJson"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4196">parseJson <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</a></code></h4>
+<h4 id="parseJson"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4196">parseJson</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a predicate and a string which may or may not be valid JSON, and
 returns Just the result of applying <code>JSON.parse</code> to the string <em>if</em> the
@@ -4250,7 +4250,7 @@ result satisfies the predicate; Nothing otherwise.</p>
 <a class="pilcrow h3" href="#regexp">¶</a>
 <h3 id="regexp">RegExp</h3>
 <a class="pilcrow h4" href="#regex">¶</a>
-<h4 id="regex"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4239">regex <span class="tight">:</span><span class="tight">:</span> RegexFlags <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> RegExp</a></code></h4>
+<h4 id="regex"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4239">regex</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#RegexFlags">RegexFlags</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#RegExp">RegExp</a></code></h4>
 
 <p>Takes a <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#RegexFlags">RegexFlags</a> and a pattern, and returns a RegExp.</p>
 <div class="examples">
@@ -4261,7 +4261,7 @@ result satisfies the predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#regexEscape">¶</a>
-<h4 id="regexEscape"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4252">regexEscape <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="regexEscape"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4252">regexEscape</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Takes a string which may contain regular expression metacharacters,
 and returns a string with those metacharacters escaped.</p>
@@ -4277,7 +4277,7 @@ and returns a string with those metacharacters escaped.</p>
 </div>
 
 <a class="pilcrow h4" href="#test">¶</a>
-<h4 id="test"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4270">test <span class="tight">:</span><span class="tight">:</span> RegExp <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</a></code></h4>
+<h4 id="test"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4270">test</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#RegExp">RegExp</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Boolean">Boolean</a></code></h4>
 
 <p>Takes a pattern and a string, and returns <code>true</code> if the pattern
 matches the string; <code>false</code> otherwise.</p>
@@ -4293,7 +4293,7 @@ matches the string; <code>false</code> otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#match">¶</a>
-<h4 id="match"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4287">match <span class="tight">:</span><span class="tight">:</span> NonGlobalRegExp <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</a></code></h4>
+<h4 id="match"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4287">match</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#NonGlobalRegExp">NonGlobalRegExp</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> { match <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a>, groups <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> (<a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a>) }</code></h4>
 
 <p>Takes a pattern and a string, and returns Just a match record if the
 pattern matches the string; Nothing otherwise.</p>
@@ -4317,7 +4317,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#matchAll">¶</a>
-<h4 id="matchAll"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4315">matchAll <span class="tight">:</span><span class="tight">:</span> GlobalRegExp <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</a></code></h4>
+<h4 id="matchAll"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4315">matchAll</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#GlobalRegExp">GlobalRegExp</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> { match <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a>, groups <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> (<a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a>) }</code></h4>
 
 <p>Takes a pattern and a string, and returns an array of match records.</p>
 <p><code>groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String)</code> acknowledges the existence of optional
@@ -4337,7 +4337,7 @@ capturing groups.</p>
 <a class="pilcrow h3" href="#string">¶</a>
 <h3 id="string">String</h3>
 <a class="pilcrow h4" href="#toUpper">¶</a>
-<h4 id="toUpper"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4347">toUpper <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="toUpper"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4347">toUpper</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Returns the upper-case equivalent of its argument.</p>
 <p>See also <a href="#toLower"><code>toLower</code></a>.</p>
@@ -4349,7 +4349,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#toLower">¶</a>
-<h4 id="toLower"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4362">toLower <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="toLower"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4362">toLower</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Returns the lower-case equivalent of its argument.</p>
 <p>See also <a href="#toUpper"><code>toUpper</code></a>.</p>
@@ -4361,7 +4361,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#trim">¶</a>
-<h4 id="trim"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4377">trim <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="trim"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4377">trim</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Strips leading and trailing whitespace characters.</p>
 <div class="examples">
@@ -4372,7 +4372,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#stripPrefix">¶</a>
-<h4 id="stripPrefix"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4390">stripPrefix <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe String</a></code></h4>
+<h4 id="stripPrefix"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4390">stripPrefix</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Returns Just the portion of the given string (the second argument) left
 after removing the given prefix (the first argument) if the string starts
@@ -4390,7 +4390,7 @@ with the prefix; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#stripSuffix">¶</a>
-<h4 id="stripSuffix"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4412">stripSuffix <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe String</a></code></h4>
+<h4 id="stripSuffix"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4412">stripSuffix</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Returns Just the portion of the given string (the second argument) left
 after removing the given suffix (the first argument) if the string ends
@@ -4408,7 +4408,7 @@ with the suffix; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#words">¶</a>
-<h4 id="words"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4434">words <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String</a></code></h4>
+<h4 id="words"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4434">words</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Takes a string and returns the array of words the string contains
 (words are delimited by whitespace characters).</p>
@@ -4421,7 +4421,7 @@ with the suffix; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#unwords">¶</a>
-<h4 id="unwords"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4452">unwords <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="unwords"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4452">unwords</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Takes an array of words and returns the result of joining the words
 with separating spaces.</p>
@@ -4434,7 +4434,7 @@ with separating spaces.</p>
 </div>
 
 <a class="pilcrow h4" href="#lines">¶</a>
-<h4 id="lines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4468">lines <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String</a></code></h4>
+<h4 id="lines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4468">lines</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Takes a string and returns the array of lines the string contains
 (lines are delimited by newlines: <code>&#39;\n&#39;</code> or <code>&#39;\r\n&#39;</code> or <code>&#39;\r&#39;</code>).
@@ -4448,7 +4448,7 @@ The resulting strings do not contain newlines.</p>
 </div>
 
 <a class="pilcrow h4" href="#unlines">¶</a>
-<h4 id="unlines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4486">unlines <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</a></code></h4>
+<h4 id="unlines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4486">unlines</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Takes an array of lines and returns the result of joining the lines
 after appending a terminating line feed (<code>&#39;\n&#39;</code>) to each.</p>
@@ -4461,7 +4461,7 @@ after appending a terminating line feed (<code>&#39;\n&#39;</code>) to each.</p>
 </div>
 
 <a class="pilcrow h4" href="#splitOn">¶</a>
-<h4 id="splitOn"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4502">splitOn <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String</a></code></h4>
+<h4 id="splitOn"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4502">splitOn</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Returns the substrings of its second argument separated by occurrences
 of its first argument.</p>
@@ -4474,7 +4474,7 @@ of its first argument.</p>
 </div>
 
 <a class="pilcrow h4" href="#splitOnRegex">¶</a>
-<h4 id="splitOnRegex"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4519">splitOnRegex <span class="tight">:</span><span class="tight">:</span> GlobalRegExp <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String</a></code></h4>
+<h4 id="splitOnRegex"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.1/index.js#L4519">splitOnRegex</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#GlobalRegExp">GlobalRegExp</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#String">String</a></code></h4>
 
 <p>Takes a pattern and a string, and returns the result of splitting the
 string at every non-overlapping occurrence of the pattern.</p>

--- a/scripts/generate
+++ b/scripts/generate
@@ -10,7 +10,10 @@ const envvar            = require('envvar');
 const marked            = require('marked');
 const R                 = require('ramda');
 const S_                = require('sanctuary');
+const pkg               = require('sanctuary/package.json');
 const $                 = require('sanctuary-def');
+const Z                 = require('sanctuary-type-classes');
+const type              = require('sanctuary-type-identifiers');
 
 
 const checkTypes        = envvar.boolean('SANCTUARY_CHECK_TYPES', true);
@@ -23,9 +26,11 @@ const I                 = S.I;
 const Just              = S.Just;
 const K                 = S.K;
 const Left              = S.Left;
+const Maybe             = S.MaybeType;
 const Nothing           = S.Nothing;
 const Right             = S.Right;
 const _                 = S.__;
+const allPass           = S.allPass;
 const ap                = S.ap;
 const apply             = R.apply;
 const at                = S.at;
@@ -51,11 +56,13 @@ const is                = S.is;
 const join              = S.join;
 const joinWith          = S.joinWith;
 const justs             = S.justs;
+const keys              = S.keys;
 const lensProp          = R.lensProp;
 const lift2             = S.lift2;
 const map               = S.map;
 const match             = S.match;
 const matchAll          = S.matchAll;
+const maybe_            = S.maybe_;
 const maybeToEither     = S.maybeToEither;
 const of                = S.of;
 const over              = R.over;
@@ -69,7 +76,10 @@ const repeat            = R.repeat;
 const replace           = R.replace;
 const sequence          = S.sequence;
 const slice_            = R.slice;
+const sort              = S.sort;
+const split             = R.split;
 const splitOnRegex      = S.splitOnRegex;
+const test              = S.test;
 const toString          = S.toString;
 const unapply           = R.unapply;
 const unfoldr           = S.unfoldr;
@@ -81,6 +91,19 @@ const green             = '\u001B[32m';
 
 //    Fn :: (Type, Type) -> Type
 const Fn = (x, y) => $.Function([x, y]);
+
+//    a :: Type
+const a = $.TypeVariable('a');
+
+//    fromJust :: Maybe a -> a !
+const fromJust =
+def('fromJust',
+    {},
+    [Maybe(a), a],
+    maybe_(() => { throw new Error('fromJust applied to Nothing'); }, I));
+
+//    j :: Array String -> String
+const j = def('j', {}, [$.Array($.String), $.String], joinWith(''));
 
 //    replace_ :: RegExp -> ([String] -> String) -> String -> String
 const replace_ =
@@ -107,13 +130,61 @@ def('wrap',
     [$.String, $.String, $.String, $.String],
     (before, after, middle) => `${before}${middle}${after}`);
 
-//    el :: String -> String -> String -> String
+//    el :: String -> StrMap String -> String -> String
 const el =
 def('el',
     {},
-    [$.String, $.String, $.String, $.String],
-    (tagName, className, innerHtml) =>
-      `<${tagName} class="${className}">${innerHtml}</${tagName}>`);
+    [$.String, $.StrMap($.String), $.String, $.String],
+    (tagName, attrs, innerHtml) => {
+      const attrsHtml = j(map(k => ` ${k}="${attrs[k]}"`, sort(keys(attrs))));
+      return `<${tagName}${attrsHtml}>${innerHtml}</${tagName}>`;
+    });
+
+//    Version :: Type
+const Version =
+$.NullaryType('sanctuary-site/Version',
+              '',
+              allPass([is(String), test(/^\d+[.]\d+[.]\d+$/)]));
+
+//    dependencyVersion :: String -> Maybe Version
+const dependencyVersion =
+def('dependencyVersion',
+    {},
+    [$.String, Maybe(Version)],
+    get($.test([], Version), _, pkg.dependencies));
+
+//    dependencyUrl :: String -> Maybe String
+const dependencyUrl =
+def('dependencyUrl',
+    {},
+    [$.String, Maybe($.String)],
+    name => map(concat(`https://github.com/sanctuary-js/${name}/tree/v`),
+                dependencyVersion(name)));
+
+//    linkTokens :: String -> String
+const linkTokens = cond([
+  [s => is(Z.TypeClass, Z[s]),
+   s => {
+     const href = fromJust(dependencyUrl('sanctuary-type-classes')) + '#' + s;
+     return el('a', {href}, s);
+   }],
+  [s => {
+     const x = $[s];
+     const pattern = `^${regexEscape(s)} :: (?:Type -> )*Type$`;
+     return $.test([], $.Type, x) ||
+            type(x) === 'Function' && test(regex('', pattern), String(x));
+   },
+   s => {
+     const href = fromJust(dependencyUrl('sanctuary-def')) + '#' + s;
+     return el('a', {href}, s);
+   }],
+  [equals('Accessible'), el('a', {href: '#accessible-pseudotype'})],
+  [equals('Either'),     el('a', {href: '#EitherType'})],
+  [equals('List'),       el('a', {href: '#list'})],
+  [equals('Maybe'),      el('a', {href: '#MaybeType'})],
+  [equals('TypeRep'),    el('a', {href: '#type-representatives'})],
+  [K(true),              I],
+]);
 
 //    toInputMarkup :: String -> String
 const toInputMarkup =
@@ -136,12 +207,10 @@ def('toOutputMarkup',
                               {displayErrors: false})),
           either(pipe([concat('! '),
                        htmlEncode,
-                       wrap('<div class="output" data-error="true">',
-                            '</div>')]),
+                       el('div', {class: 'output', 'data-error': 'true'})]),
                  pipe([toString,
                        htmlEncode,
-                       wrap('<div class="output">',
-                            '</div>')]))]));
+                       el('div', {class: 'output'})]))]));
 
 //    doctestsToMarkup :: String -> String
 const doctestsToMarkup =
@@ -160,7 +229,7 @@ def('doctestsToMarkup',
           map(map(concat('    '))),
           map(unlines),
           map(wrap('  <form>\n', '  </form>\n')),
-          joinWith(''),
+          j,
           wrap('<div class="examples">\n', '</div>\n')]));
 
 //    substitutionPattern :: RegExp
@@ -175,25 +244,25 @@ def('substitutions',
     replace_(substitutionPattern,
              apply(cond([[equals(' :: '),
                           K(' ' +
-                            el('span', 'tight', ':') +
-                            el('span', 'tight', ':') +
+                            el('span', {class: 'tight'}, ':') +
+                            el('span', {class: 'tight'}, ':') +
                             ' ')],
                          [elem(_, ap([I, htmlEncode], ['=>'])),
-                          K(el('span', 'arrow', htmlEncode('=>')))],
+                          K(el('span', {class: 'arrow'}, htmlEncode('=>')))],
                          [elem(_, ap([I, htmlEncode], ['~>'])),
-                          K(el('span', 'arrow', htmlEncode('~>')))],
+                          K(el('span', {class: 'arrow'}, htmlEncode('~>')))],
                          [elem(_, ap([I, htmlEncode], ['->'])),
-                          K(el('span', 'arrow',
-                               el('span', 'arrow-hyphen', htmlEncode('-')) +
-                               htmlEncode('>')))],
+                          K(el('span', {class: 'arrow'},
+                               el('span', {class: 'arrow-hyphen'}, htmlEncode('-'))
+                               + htmlEncode('>')))],
                          [equals('-\u2060>'),
-                          K(el('span', 'arrow',
-                               el('span', 'arrow-hyphen', htmlEncode('-')) +
-                               htmlEncode('\u2060>')))],
+                          K(el('span', {class: 'arrow'},
+                               el('span', {class: 'arrow-hyphen'}, htmlEncode('-'))
+                               + htmlEncode('\u2060>')))],
                          [equals('...'),
-                          K(el('span', 'tight', '.') +
-                            el('span', 'tight', '.') +
-                            el('span', 'tight', '.'))],
+                          K(el('span', {class: 'tight'}, '.') +
+                            el('span', {class: 'tight'}, '.') +
+                            el('span', {class: 'tight'}, '.'))],
                          [K(true),
                           I]]))));
 
@@ -202,7 +271,12 @@ const generate =
 def('generate',
     {},
     [$.String, $.String],
-    pipe([replace(/<h4 name=/g, '<h4 id='),
+    pipe([replace_(regex('g', '<h4 name="(.*)"><code><a href="(.*)">([^ ]*)(.*)</a></code></h4>'),
+                   ([id, href, name, _innerHtml]) =>
+                     el('h4', {id},
+                        el('code', {},
+                           el('a', {href}, name)
+                           + j(map(linkTokens, split(/(\w+)/, _innerHtml)))))),
           replace_(/^```javascript\n(> [\s\S]*?)^```\n/gm,
                    apply(doctestsToMarkup)),
           //  Replace NO-BREAK SPACE characters with SYMBOL FOR SPACE
@@ -289,11 +363,7 @@ def('readme',
           map(replace(/\n$/, ''))]));
 
 //    pad :: Integer -> String
-const pad =
-def('pad',
-    {},
-    [$.Integer, $.String],
-    compose(joinWith(''), repeat('  ')));
+const pad = def('pad', {}, [$.Integer, $.String], compose(j, repeat('  ')));
 
 //    colon :: String
 const colon = regexEscape('<span class="tight">:</span>');
@@ -314,8 +384,11 @@ def('toc',
             const level$ = Number(hN[1]);
             const level$$ = level$ > level ? hN === tagName ? level : level + 1 : level$;
 
+            const pattern = '<a [^>]*>([^<]*)</a>';
             const innerHtml =
-            replace(/^(<code><a [^>]*>)([^ ]*)/, '$1<b>$2</b>', _innerHtml);
+            pipe([replace(regex('', pattern), '<b>$1</b>'),
+                  replace(regex('g', pattern), '$1')],
+                 _innerHtml);
 
             const html$ =
             html + '\n' +
@@ -337,15 +410,15 @@ def('toc',
                   map(prop('groups')),
                   chain(head),
                   join,
-                  map(wrap('<code>', '</code>')),
+                  map(el('code', {})),
                   fromMaybe(innerHtml),
-                  wrap('<a href="#' + id + '">', '</a>')],
+                  el('a', {href: '#' + id})],
                  innerHtml);
 
             return {level: level$$, tagName: hN, html: html$};
           }, {level: 1, tagName: 'h1', html: ''}),
           over(lensProp('level'),
-               compose(joinWith(''),
+               compose(j,
                        unfoldr(level => level > 1 ?
                                  Just(['\n' + pad(2 * level - 1) + '</li>' +
                                        '\n' + pad(2 * level - 2) + '</ul>',

--- a/style.css
+++ b/style.css
@@ -215,6 +215,10 @@ h1 small {
   font-weight: normal;
 }
 
+h4 code {
+  color: #333;
+}
+
 p {
   margin: 1em 0;
 }


### PR DESCRIPTION
### Before

Currently the entire signature links to the source code.

<img alt="Before" src="https://cloud.githubusercontent.com/assets/210406/25556761/179c126c-2d03-11e7-90f1-8ae9c15dc600.png" width="500" height="122">

### After

With this change only the function name will link to the source code. Types and type classes will link to the appropriate documentation. In the example below, `ChainRec` links to [`Z.ChainRec`][1], `TypeRep` to [type representatives][2], and `Either` to [`S.EitherType`][3].

<img alt="After" src="https://cloud.githubusercontent.com/assets/210406/25556762/1d87086c-2d03-11e7-992d-1d368e572dd0.png" width="500" height="122">

---

I encourage you to play with this locally. There's nothing to install or build – simply open __index.html__ in a browser. :)


[1]: https://github.com/sanctuary-js/sanctuary-type-classes/tree/v3.0.1#ChainRec
[2]: https://sanctuary.js.org/#type-representatives
[3]: https://sanctuary.js.org/#MaybeType
