### PR TITLE
use Fira Code

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
                        location.hash);
     }
   </script>
+  <link rel="stylesheet" href="https://cdn.rawgit.com/tonsky/FiraCode/1.204/distr/fira_code.css">
   <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" href="favicon.png">
   <link rel="mask-icon" href="mask-icon.svg" color="#080">
@@ -53,16 +54,16 @@
         <a href="#api">API</a>
         <ul>
           <li>
-            <a href="#create"><code><b>create</b> <span class="tight">:</span><span class="tight">:</span> { checkTypes <span class="tight">:</span><span class="tight">:</span> Boolean, env <span class="tight">:</span><span class="tight">:</span> Array Type } <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Module</code></a>
+            <a href="#create"><code><b>create</b> :: { checkTypes :: Boolean, env :: Array Type } -> Module</code></a>
           </li>
           <li>
-            <a href="#env"><code><b>env</b> <span class="tight">:</span><span class="tight">:</span> Array Type</code></a>
+            <a href="#env"><code><b>env</b> :: Array Type</code></a>
           </li>
           <li>
             <a href="#placeholder">Placeholder</a>
             <ul>
               <li>
-                <a href="#__"><code><b>__</b> <span class="tight">:</span><span class="tight">:</span> Placeholder</code></a>
+                <a href="#__"><code><b>__</b> :: Placeholder</code></a>
               </li>
             </ul>
           </li>
@@ -70,10 +71,10 @@
             <a href="#classify">Classify</a>
             <ul>
               <li>
-                <a href="#type"><code><b>type</b> <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> { namespace <span class="tight">:</span><span class="tight">:</span> Maybe String, name <span class="tight">:</span><span class="tight">:</span> String, version <span class="tight">:</span><span class="tight">:</span> Integer }</code></a>
+                <a href="#type"><code><b>type</b> :: Any -> { namespace :: Maybe String, name :: String, version :: Integer }</code></a>
               </li>
               <li>
-                <a href="#is"><code><b>is</b> <span class="tight">:</span><span class="tight">:</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#is"><code><b>is</b> :: TypeRep a -> Any -> Boolean</code></a>
               </li>
             </ul>
           </li>
@@ -81,7 +82,7 @@
             <a href="#showable">Showable</a>
             <ul>
               <li>
-                <a href="#toString"><code><b>toString</b> <span class="tight">:</span><span class="tight">:</span> Any <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#toString"><code><b>toString</b> :: Any -> String</code></a>
               </li>
             </ul>
           </li>
@@ -89,121 +90,121 @@
             <a href="#fantasy-land">Fantasy Land</a>
             <ul>
               <li>
-                <a href="#equals"><code><b>equals</b> <span class="tight">:</span><span class="tight">:</span> Setoid a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#equals"><code><b>equals</b> :: Setoid a => a -> a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#lt"><code><b>lt</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean)</code></a>
+                <a href="#lt"><code><b>lt</b> :: Ord a => a -> (a -> Boolean)</code></a>
               </li>
               <li>
-                <a href="#lt_"><code><b>lt_</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#lt_"><code><b>lt_</b> :: Ord a => a -> a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#lte"><code><b>lte</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean)</code></a>
+                <a href="#lte"><code><b>lte</b> :: Ord a => a -> (a -> Boolean)</code></a>
               </li>
               <li>
-                <a href="#lte_"><code><b>lte_</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#lte_"><code><b>lte_</b> :: Ord a => a -> a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#gt"><code><b>gt</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean)</code></a>
+                <a href="#gt"><code><b>gt</b> :: Ord a => a -> (a -> Boolean)</code></a>
               </li>
               <li>
-                <a href="#gt_"><code><b>gt_</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#gt_"><code><b>gt_</b> :: Ord a => a -> a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#gte"><code><b>gte</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean)</code></a>
+                <a href="#gte"><code><b>gte</b> :: Ord a => a -> (a -> Boolean)</code></a>
               </li>
               <li>
-                <a href="#gte_"><code><b>gte_</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#gte_"><code><b>gte_</b> :: Ord a => a -> a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#min"><code><b>min</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#min"><code><b>min</b> :: Ord a => a -> a -> a</code></a>
               </li>
               <li>
-                <a href="#max"><code><b>max</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#max"><code><b>max</b> :: Ord a => a -> a -> a</code></a>
               </li>
               <li>
-                <a href="#id"><code><b>id</b> <span class="tight">:</span><span class="tight">:</span> Category c <span class="arrow">=&gt;</span> TypeRep c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></a>
+                <a href="#id"><code><b>id</b> :: Category c => TypeRep c -> c</code></a>
               </li>
               <li>
-                <a href="#concat"><code><b>concat</b> <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#concat"><code><b>concat</b> :: Semigroup a => a -> a -> a</code></a>
               </li>
               <li>
-                <a href="#empty"><code><b>empty</b> <span class="tight">:</span><span class="tight">:</span> Monoid a <span class="arrow">=&gt;</span> TypeRep a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#empty"><code><b>empty</b> :: Monoid a => TypeRep a -> a</code></a>
               </li>
               <li>
-                <a href="#map"><code><b>map</b> <span class="tight">:</span><span class="tight">:</span> Functor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></a>
+                <a href="#map"><code><b>map</b> :: Functor f => (a -> b) -> f a -> f b</code></a>
               </li>
               <li>
-                <a href="#bimap"><code><b>bimap</b> <span class="tight">:</span><span class="tight">:</span> Bifunctor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b d</code></a>
+                <a href="#bimap"><code><b>bimap</b> :: Bifunctor f => (a -> b) -> (c -> d) -> f a c -> f b d</code></a>
               </li>
               <li>
-                <a href="#promap"><code><b>promap</b> <span class="tight">:</span><span class="tight">:</span> Profunctor p <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> p b c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> p a d</code></a>
+                <a href="#promap"><code><b>promap</b> :: Profunctor p => (a -> b) -> (c -> d) -> p b c -> p a d</code></a>
               </li>
               <li>
-                <a href="#alt"><code><b>alt</b> <span class="tight">:</span><span class="tight">:</span> Alt f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></a>
+                <a href="#alt"><code><b>alt</b> :: Alt f => f a -> f a -> f a</code></a>
               </li>
               <li>
-                <a href="#zero"><code><b>zero</b> <span class="tight">:</span><span class="tight">:</span> Plus f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></a>
+                <a href="#zero"><code><b>zero</b> :: Plus f => TypeRep f -> f a</code></a>
               </li>
               <li>
-                <a href="#reduce"><code><b>reduce</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#reduce"><code><b>reduce</b> :: Foldable f => (b -> a -> b) -> b -> f a -> b</code></a>
               </li>
               <li>
-                <a href="#reduce_"><code><b>reduce_</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#reduce_"><code><b>reduce_</b> :: Foldable f => ((b, a) -> b) -> b -> f a -> b</code></a>
               </li>
               <li>
-                <a href="#traverse"><code><b>traverse</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> t a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (t b)</code></a>
+                <a href="#traverse"><code><b>traverse</b> :: (Applicative f, Traversable t) => TypeRep f -> (a -> f b) -> t a -> f (t b)</code></a>
               </li>
               <li>
-                <a href="#sequence"><code><b>sequence</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Traversable t) <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> t (f a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (t a)</code></a>
+                <a href="#sequence"><code><b>sequence</b> :: (Applicative f, Traversable t) => TypeRep f -> t (f a) -> f (t a)</code></a>
               </li>
               <li>
-                <a href="#ap"><code><b>ap</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></a>
+                <a href="#ap"><code><b>ap</b> :: Apply f => f (a -> b) -> f a -> f b</code></a>
               </li>
               <li>
-                <a href="#lift2"><code><b>lift2</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c</code></a>
+                <a href="#lift2"><code><b>lift2</b> :: Apply f => (a -> b -> c) -> f a -> f b -> f c</code></a>
               </li>
               <li>
-                <a href="#lift3"><code><b>lift3</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f d</code></a>
+                <a href="#lift3"><code><b>lift3</b> :: Apply f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d</code></a>
               </li>
               <li>
-                <a href="#apFirst"><code><b>apFirst</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></a>
+                <a href="#apFirst"><code><b>apFirst</b> :: Apply f => f a -> f b -> f a</code></a>
               </li>
               <li>
-                <a href="#apSecond"><code><b>apSecond</b> <span class="tight">:</span><span class="tight">:</span> Apply f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></a>
+                <a href="#apSecond"><code><b>apSecond</b> :: Apply f => f a -> f b -> f b</code></a>
               </li>
               <li>
-                <a href="#of"><code><b>of</b> <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> TypeRep f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></a>
+                <a href="#of"><code><b>of</b> :: Applicative f => TypeRep f -> a -> f a</code></a>
               </li>
               <li>
-                <a href="#chain"><code><b>chain</b> <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b</code></a>
+                <a href="#chain"><code><b>chain</b> :: Chain m => (a -> m b) -> m a -> m b</code></a>
               </li>
               <li>
-                <a href="#join"><code><b>join</b> <span class="tight">:</span><span class="tight">:</span> Chain m <span class="arrow">=&gt;</span> m (m a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></a>
+                <a href="#join"><code><b>join</b> :: Chain m => m (m a) -> m a</code></a>
               </li>
               <li>
-                <a href="#chainRec"><code><b>chainRec</b> <span class="tight">:</span><span class="tight">:</span> ChainRec m <span class="arrow">=&gt;</span> TypeRep m <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m (Either a b)) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b</code></a>
+                <a href="#chainRec"><code><b>chainRec</b> :: ChainRec m => TypeRep m -> (a -> m (Either a b)) -> a -> m b</code></a>
               </li>
               <li>
-                <a href="#extend"><code><b>extend</b> <span class="tight">:</span><span class="tight">:</span> Extend w <span class="arrow">=&gt;</span> (w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> w b</code></a>
+                <a href="#extend"><code><b>extend</b> :: Extend w => (w a -> b) -> w a -> w b</code></a>
               </li>
               <li>
-                <a href="#extract"><code><b>extract</b> <span class="tight">:</span><span class="tight">:</span> Comonad w <span class="arrow">=&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#extract"><code><b>extract</b> :: Comonad w => w a -> a</code></a>
               </li>
               <li>
-                <a href="#contramap"><code><b>contramap</b> <span class="tight">:</span><span class="tight">:</span> Contravariant f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></a>
+                <a href="#contramap"><code><b>contramap</b> :: Contravariant f => (b -> a) -> f a -> f b</code></a>
               </li>
               <li>
-                <a href="#filter"><code><b>filter</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Foldable f, Monoid (f a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></a>
+                <a href="#filter"><code><b>filter</b> :: (Applicative f, Foldable f, Monoid (f a)) => (a -> Boolean) -> f a -> f a</code></a>
               </li>
               <li>
-                <a href="#filterM"><code><b>filterM</b> <span class="tight">:</span><span class="tight">:</span> (Alternative m, Monad m) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></a>
+                <a href="#filterM"><code><b>filterM</b> :: (Alternative m, Monad m) => (a -> Boolean) -> m a -> m a</code></a>
               </li>
               <li>
-                <a href="#takeWhile"><code><b>takeWhile</b> <span class="tight">:</span><span class="tight">:</span> (Foldable f, Alternative f) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></a>
+                <a href="#takeWhile"><code><b>takeWhile</b> :: (Foldable f, Alternative f) => (a -> Boolean) -> f a -> f a</code></a>
               </li>
               <li>
-                <a href="#dropWhile"><code><b>dropWhile</b> <span class="tight">:</span><span class="tight">:</span> (Foldable f, Alternative f) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></a>
+                <a href="#dropWhile"><code><b>dropWhile</b> :: (Foldable f, Alternative f) => (a -> Boolean) -> f a -> f a</code></a>
               </li>
             </ul>
           </li>
@@ -211,16 +212,16 @@
             <a href="#combinator">Combinator</a>
             <ul>
               <li>
-                <a href="#I"><code><b>I</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#I"><code><b>I</b> :: a -> a</code></a>
               </li>
               <li>
-                <a href="#K"><code><b>K</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#K"><code><b>K</b> :: a -> b -> a</code></a>
               </li>
               <li>
-                <a href="#A"><code><b>A</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#A"><code><b>A</b> :: (a -> b) -> a -> b</code></a>
               </li>
               <li>
-                <a href="#T"><code><b>T</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#T"><code><b>T</b> :: a -> (a -> b) -> b</code></a>
               </li>
             </ul>
           </li>
@@ -228,22 +229,22 @@
             <a href="#function">Function</a>
             <ul>
               <li>
-                <a href="#curry2"><code><b>curry2</b> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></a>
+                <a href="#curry2"><code><b>curry2</b> :: ((a, b) -> c) -> a -> b -> c</code></a>
               </li>
               <li>
-                <a href="#curry3"><code><b>curry3</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d</code></a>
+                <a href="#curry3"><code><b>curry3</b> :: ((a, b, c) -> d) -> a -> b -> c -> d</code></a>
               </li>
               <li>
-                <a href="#curry4"><code><b>curry4</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e</code></a>
+                <a href="#curry4"><code><b>curry4</b> :: ((a, b, c, d) -> e) -> a -> b -> c -> d -> e</code></a>
               </li>
               <li>
-                <a href="#curry5"><code><b>curry5</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d, e) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f</code></a>
+                <a href="#curry5"><code><b>curry5</b> :: ((a, b, c, d, e) -> f) -> a -> b -> c -> d -> e -> f</code></a>
               </li>
               <li>
-                <a href="#flip"><code><b>flip</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></a>
+                <a href="#flip"><code><b>flip</b> :: (a -> b -> c) -> b -> a -> c</code></a>
               </li>
               <li>
-                <a href="#flip_"><code><b>flip_</b> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></a>
+                <a href="#flip_"><code><b>flip_</b> :: ((a, b) -> c) -> b -> a -> c</code></a>
               </li>
             </ul>
           </li>
@@ -251,16 +252,16 @@
             <a href="#composition">Composition</a>
             <ul>
               <li>
-                <a href="#compose"><code><b>compose</b> <span class="tight">:</span><span class="tight">:</span> Semigroupoid s <span class="arrow">=&gt;</span> s b c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> s a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> s a c</code></a>
+                <a href="#compose"><code><b>compose</b> :: Semigroupoid s => s b c -> s a b -> s a c</code></a>
               </li>
               <li>
-                <a href="#pipe"><code><b>pipe</b> <span class="tight">:</span><span class="tight">:</span> [(a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b), (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c), <span class="tight">.</span><span class="tight">.</span><span class="tight">.</span>, (m <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> n)] <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> n</code></a>
+                <a href="#pipe"><code><b>pipe</b> :: [(a -> b), (b -> c), ..., (m -> n)] -> a -> n</code></a>
               </li>
               <li>
-                <a href="#on"><code><b>on</b> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></a>
+                <a href="#on"><code><b>on</b> :: (b -> b -> c) -> (a -> b) -> a -> a -> c</code></a>
               </li>
               <li>
-                <a href="#on_"><code><b>on_</b> <span class="tight">:</span><span class="tight">:</span> ((b, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></a>
+                <a href="#on_"><code><b>on_</b> :: ((b, b) -> c) -> (a -> b) -> a -> a -> c</code></a>
               </li>
             </ul>
           </li>
@@ -268,118 +269,118 @@
             <a href="#maybe-type">Maybe type</a>
             <ul>
               <li>
-                <a href="#MaybeType"><code><b>MaybeType</b> <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Type</code></a>
+                <a href="#MaybeType"><code><b>MaybeType</b> :: Type -> Type</code></a>
               </li>
               <li>
-                <a href="#Maybe"><code><b>Maybe</b> <span class="tight">:</span><span class="tight">:</span> TypeRep Maybe</code></a>
+                <a href="#Maybe"><code><b>Maybe</b> :: TypeRep Maybe</code></a>
               </li>
               <li>
-                <a href="#Nothing"><code><b>Nothing</b> <span class="tight">:</span><span class="tight">:</span> Maybe a</code></a>
+                <a href="#Nothing"><code><b>Nothing</b> :: Maybe a</code></a>
               </li>
               <li>
-                <a href="#Just"><code><b>Just</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#Just"><code><b>Just</b> :: a -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Maybe.@@type"><code><b>Maybe.@@type</b> <span class="tight">:</span><span class="tight">:</span> String</code></a>
+                <a href="#Maybe.@@type"><code><b>Maybe.@@type</b> :: String</code></a>
               </li>
               <li>
-                <a href="#Maybe.fantasy-land/empty"><code><b>Maybe.fantasy-land/empty</b> <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#Maybe.fantasy-land/empty"><code><b>Maybe.fantasy-land/empty</b> :: () -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Maybe.fantasy-land/of"><code><b>Maybe.fantasy-land/of</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#Maybe.fantasy-land/of"><code><b>Maybe.fantasy-land/of</b> :: a -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Maybe.fantasy-land/zero"><code><b>Maybe.fantasy-land/zero</b> <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#Maybe.fantasy-land/zero"><code><b>Maybe.fantasy-land/zero</b> :: () -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.isNothing"><code><b>Maybe#isNothing</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Boolean</code></a>
+                <a href="#Maybe.prototype.isNothing"><code><b>Maybe#isNothing</b> :: Maybe a ~> Boolean</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.isJust"><code><b>Maybe#isJust</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Boolean</code></a>
+                <a href="#Maybe.prototype.isJust"><code><b>Maybe#isJust</b> :: Maybe a ~> Boolean</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.toString"><code><b>Maybe#toString</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#Maybe.prototype.toString"><code><b>Maybe#toString</b> :: Maybe a ~> () -> String</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.inspect"><code><b>Maybe#inspect</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#Maybe.prototype.inspect"><code><b>Maybe#inspect</b> :: Maybe a ~> () -> String</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/equals"><code><b>Maybe#fantasy-land/equals</b> <span class="tight">:</span><span class="tight">:</span> Setoid a <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#Maybe.prototype.fantasy-land/equals"><code><b>Maybe#fantasy-land/equals</b> :: Setoid a => Maybe a ~> Maybe a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/lte"><code><b>Maybe#fantasy-land/lte</b> <span class="tight">:</span><span class="tight">:</span> Ord a <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#Maybe.prototype.fantasy-land/lte"><code><b>Maybe#fantasy-land/lte</b> :: Ord a => Maybe a ~> Maybe a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/concat"><code><b>Maybe#fantasy-land/concat</b> <span class="tight">:</span><span class="tight">:</span> Semigroup a <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#Maybe.prototype.fantasy-land/concat"><code><b>Maybe#fantasy-land/concat</b> :: Semigroup a => Maybe a ~> Maybe a -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/map"><code><b>Maybe#fantasy-land/map</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</code></a>
+                <a href="#Maybe.prototype.fantasy-land/map"><code><b>Maybe#fantasy-land/map</b> :: Maybe a ~> (a -> b) -> Maybe b</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/ap"><code><b>Maybe#fantasy-land/ap</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</code></a>
+                <a href="#Maybe.prototype.fantasy-land/ap"><code><b>Maybe#fantasy-land/ap</b> :: Maybe a ~> Maybe (a -> b) -> Maybe b</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/chain"><code><b>Maybe#fantasy-land/chain</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</code></a>
+                <a href="#Maybe.prototype.fantasy-land/chain"><code><b>Maybe#fantasy-land/chain</b> :: Maybe a ~> (a -> Maybe b) -> Maybe b</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/alt"><code><b>Maybe#fantasy-land/alt</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#Maybe.prototype.fantasy-land/alt"><code><b>Maybe#fantasy-land/alt</b> :: Maybe a ~> Maybe a -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/reduce"><code><b>Maybe#fantasy-land/reduce</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#Maybe.prototype.fantasy-land/reduce"><code><b>Maybe#fantasy-land/reduce</b> :: Maybe a ~> ((b, a) -> b, b) -> b</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/traverse"><code><b>Maybe#fantasy-land/traverse</b> <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Maybe a <span class="arrow">~&gt;</span> (TypeRep f, a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (Maybe b)</code></a>
+                <a href="#Maybe.prototype.fantasy-land/traverse"><code><b>Maybe#fantasy-land/traverse</b> :: Applicative f => Maybe a ~> (TypeRep f, a -> f b) -> f (Maybe b)</code></a>
               </li>
               <li>
-                <a href="#Maybe.prototype.fantasy-land/extend"><code><b>Maybe#fantasy-land/extend</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow">~&gt;</span> (Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</code></a>
+                <a href="#Maybe.prototype.fantasy-land/extend"><code><b>Maybe#fantasy-land/extend</b> :: Maybe a ~> (Maybe a -> b) -> Maybe b</code></a>
               </li>
               <li>
-                <a href="#isNothing"><code><b>isNothing</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#isNothing"><code><b>isNothing</b> :: Maybe a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#isJust"><code><b>isJust</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#isJust"><code><b>isJust</b> :: Maybe a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#fromMaybe"><code><b>fromMaybe</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#fromMaybe"><code><b>fromMaybe</b> :: a -> Maybe a -> a</code></a>
               </li>
               <li>
-                <a href="#fromMaybe_"><code><b>fromMaybe_</b> <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#fromMaybe_"><code><b>fromMaybe_</b> :: (() -> a) -> Maybe a -> a</code></a>
               </li>
               <li>
-                <a href="#maybeToNullable"><code><b>maybeToNullable</b> <span class="tight">:</span><span class="tight">:</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Nullable a</code></a>
+                <a href="#maybeToNullable"><code><b>maybeToNullable</b> :: Maybe a -> Nullable a</code></a>
               </li>
               <li>
-                <a href="#toMaybe"><code><b>toMaybe</b> <span class="tight">:</span><span class="tight">:</span> a? <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#toMaybe"><code><b>toMaybe</b> :: a? -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#maybe"><code><b>maybe</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#maybe"><code><b>maybe</b> :: b -> (a -> b) -> Maybe a -> b</code></a>
               </li>
               <li>
-                <a href="#maybe_"><code><b>maybe_</b> <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#maybe_"><code><b>maybe_</b> :: (() -> b) -> (a -> b) -> Maybe a -> b</code></a>
               </li>
               <li>
-                <a href="#justs"><code><b>justs</b> <span class="tight">:</span><span class="tight">:</span> Array (Maybe a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a</code></a>
+                <a href="#justs"><code><b>justs</b> :: Array (Maybe a) -> Array a</code></a>
               </li>
               <li>
-                <a href="#mapMaybe"><code><b>mapMaybe</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array b</code></a>
+                <a href="#mapMaybe"><code><b>mapMaybe</b> :: (a -> Maybe b) -> Array a -> Array b</code></a>
               </li>
               <li>
-                <a href="#encase"><code><b>encase</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</code></a>
+                <a href="#encase"><code><b>encase</b> :: (a -> b) -> a -> Maybe b</code></a>
               </li>
               <li>
-                <a href="#encase2"><code><b>encase2</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe c</code></a>
+                <a href="#encase2"><code><b>encase2</b> :: (a -> b -> c) -> a -> b -> Maybe c</code></a>
               </li>
               <li>
-                <a href="#encase2_"><code><b>encase2_</b> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe c</code></a>
+                <a href="#encase2_"><code><b>encase2_</b> :: ((a, b) -> c) -> a -> b -> Maybe c</code></a>
               </li>
               <li>
-                <a href="#encase3"><code><b>encase3</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe d</code></a>
+                <a href="#encase3"><code><b>encase3</b> :: (a -> b -> c -> d) -> a -> b -> c -> Maybe d</code></a>
               </li>
               <li>
-                <a href="#encase3_"><code><b>encase3_</b> <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe d</code></a>
+                <a href="#encase3_"><code><b>encase3_</b> :: ((a, b, c) -> d) -> a -> b -> c -> Maybe d</code></a>
               </li>
               <li>
-                <a href="#maybeToEither"><code><b>maybeToEither</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</code></a>
+                <a href="#maybeToEither"><code><b>maybeToEither</b> :: a -> Maybe b -> Either a b</code></a>
               </li>
             </ul>
           </li>
@@ -387,109 +388,109 @@
             <a href="#either-type">Either type</a>
             <ul>
               <li>
-                <a href="#EitherType"><code><b>EitherType</b> <span class="tight">:</span><span class="tight">:</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Type <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Type</code></a>
+                <a href="#EitherType"><code><b>EitherType</b> :: Type -> Type -> Type</code></a>
               </li>
               <li>
-                <a href="#Either"><code><b>Either</b> <span class="tight">:</span><span class="tight">:</span> TypeRep Either</code></a>
+                <a href="#Either"><code><b>Either</b> :: TypeRep Either</code></a>
               </li>
               <li>
-                <a href="#Left"><code><b>Left</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</code></a>
+                <a href="#Left"><code><b>Left</b> :: a -> Either a b</code></a>
               </li>
               <li>
-                <a href="#Right"><code><b>Right</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</code></a>
+                <a href="#Right"><code><b>Right</b> :: b -> Either a b</code></a>
               </li>
               <li>
-                <a href="#Either.@@type"><code><b>Either.@@type</b> <span class="tight">:</span><span class="tight">:</span> String</code></a>
+                <a href="#Either.@@type"><code><b>Either.@@type</b> :: String</code></a>
               </li>
               <li>
-                <a href="#Either.fantasy-land/of"><code><b>Either.fantasy-land/of</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</code></a>
+                <a href="#Either.fantasy-land/of"><code><b>Either.fantasy-land/of</b> :: b -> Either a b</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.isLeft"><code><b>Either#isLeft</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Boolean</code></a>
+                <a href="#Either.prototype.isLeft"><code><b>Either#isLeft</b> :: Either a b ~> Boolean</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.isRight"><code><b>Either#isRight</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Boolean</code></a>
+                <a href="#Either.prototype.isRight"><code><b>Either#isRight</b> :: Either a b ~> Boolean</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.toString"><code><b>Either#toString</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#Either.prototype.toString"><code><b>Either#toString</b> :: Either a b ~> () -> String</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.inspect"><code><b>Either#inspect</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#Either.prototype.inspect"><code><b>Either#inspect</b> :: Either a b ~> () -> String</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/equals"><code><b>Either#fantasy-land/equals</b> <span class="tight">:</span><span class="tight">:</span> (Setoid a, Setoid b) <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#Either.prototype.fantasy-land/equals"><code><b>Either#fantasy-land/equals</b> :: (Setoid a, Setoid b) => Either a b ~> Either a b -> Boolean</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/lte"><code><b>Either#fantasy-land/lte</b> <span class="tight">:</span><span class="tight">:</span> (Ord a, Ord b) <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#Either.prototype.fantasy-land/lte"><code><b>Either#fantasy-land/lte</b> :: (Ord a, Ord b) => Either a b ~> Either a b -> Boolean</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/concat"><code><b>Either#fantasy-land/concat</b> <span class="tight">:</span><span class="tight">:</span> (Semigroup a, Semigroup b) <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</code></a>
+                <a href="#Either.prototype.fantasy-land/concat"><code><b>Either#fantasy-land/concat</b> :: (Semigroup a, Semigroup b) => Either a b ~> Either a b -> Either a b</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/map"><code><b>Either#fantasy-land/map</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a c</code></a>
+                <a href="#Either.prototype.fantasy-land/map"><code><b>Either#fantasy-land/map</b> :: Either a b ~> (b -> c) -> Either a c</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/bimap"><code><b>Either#fantasy-land/bimap</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c, b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either c d</code></a>
+                <a href="#Either.prototype.fantasy-land/bimap"><code><b>Either#fantasy-land/bimap</b> :: Either a b ~> (a -> c, b -> d) -> Either c d</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/ap"><code><b>Either#fantasy-land/ap</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a c</code></a>
+                <a href="#Either.prototype.fantasy-land/ap"><code><b>Either#fantasy-land/ap</b> :: Either a b ~> Either a (b -> c) -> Either a c</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/chain"><code><b>Either#fantasy-land/chain</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a c</code></a>
+                <a href="#Either.prototype.fantasy-land/chain"><code><b>Either#fantasy-land/chain</b> :: Either a b ~> (b -> Either a c) -> Either a c</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/alt"><code><b>Either#fantasy-land/alt</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</code></a>
+                <a href="#Either.prototype.fantasy-land/alt"><code><b>Either#fantasy-land/alt</b> :: Either a b ~> Either a b -> Either a b</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/reduce"><code><b>Either#fantasy-land/reduce</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> ((c, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></a>
+                <a href="#Either.prototype.fantasy-land/reduce"><code><b>Either#fantasy-land/reduce</b> :: Either a b ~> ((c, b) -> c, c) -> c</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/traverse"><code><b>Either#fantasy-land/traverse</b> <span class="tight">:</span><span class="tight">:</span> Applicative f <span class="arrow">=&gt;</span> Either a b <span class="arrow">~&gt;</span> (TypeRep f, b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (Either a c)</code></a>
+                <a href="#Either.prototype.fantasy-land/traverse"><code><b>Either#fantasy-land/traverse</b> :: Applicative f => Either a b ~> (TypeRep f, b -> f c) -> f (Either a c)</code></a>
               </li>
               <li>
-                <a href="#Either.prototype.fantasy-land/extend"><code><b>Either#fantasy-land/extend</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow">~&gt;</span> (Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a c</code></a>
+                <a href="#Either.prototype.fantasy-land/extend"><code><b>Either#fantasy-land/extend</b> :: Either a b ~> (Either a b -> c) -> Either a c</code></a>
               </li>
               <li>
-                <a href="#isLeft"><code><b>isLeft</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#isLeft"><code><b>isLeft</b> :: Either a b -> Boolean</code></a>
               </li>
               <li>
-                <a href="#isRight"><code><b>isRight</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#isRight"><code><b>isRight</b> :: Either a b -> Boolean</code></a>
               </li>
               <li>
-                <a href="#fromEither"><code><b>fromEither</b> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#fromEither"><code><b>fromEither</b> :: b -> Either a b -> b</code></a>
               </li>
               <li>
-                <a href="#toEither"><code><b>toEither</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b? <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b</code></a>
+                <a href="#toEither"><code><b>toEither</b> :: a -> b? -> Either a b</code></a>
               </li>
               <li>
-                <a href="#either"><code><b>either</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></a>
+                <a href="#either"><code><b>either</b> :: (a -> c) -> (b -> c) -> Either a b -> c</code></a>
               </li>
               <li>
-                <a href="#lefts"><code><b>lefts</b> <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a</code></a>
+                <a href="#lefts"><code><b>lefts</b> :: Array (Either a b) -> Array a</code></a>
               </li>
               <li>
-                <a href="#rights"><code><b>rights</b> <span class="tight">:</span><span class="tight">:</span> Array (Either a b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array b</code></a>
+                <a href="#rights"><code><b>rights</b> :: Array (Either a b) -> Array b</code></a>
               </li>
               <li>
-                <a href="#tagBy"><code><b>tagBy</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either a a</code></a>
+                <a href="#tagBy"><code><b>tagBy</b> :: (a -> Boolean) -> a -> Either a a</code></a>
               </li>
               <li>
-                <a href="#encaseEither"><code><b>encaseEither</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either l r</code></a>
+                <a href="#encaseEither"><code><b>encaseEither</b> :: (Error -> l) -> (a -> r) -> a -> Either l r</code></a>
               </li>
               <li>
-                <a href="#encaseEither2"><code><b>encaseEither2</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either l r</code></a>
+                <a href="#encaseEither2"><code><b>encaseEither2</b> :: (Error -> l) -> (a -> b -> r) -> a -> b -> Either l r</code></a>
               </li>
               <li>
-                <a href="#encaseEither2_"><code><b>encaseEither2_</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either l r</code></a>
+                <a href="#encaseEither2_"><code><b>encaseEither2_</b> :: (Error -> l) -> ((a, b) -> r) -> a -> b -> Either l r</code></a>
               </li>
               <li>
-                <a href="#encaseEither3"><code><b>encaseEither3</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either l r</code></a>
+                <a href="#encaseEither3"><code><b>encaseEither3</b> :: (Error -> l) -> (a -> b -> c -> r) -> a -> b -> c -> Either l r</code></a>
               </li>
               <li>
-                <a href="#encaseEither3_"><code><b>encaseEither3_</b> <span class="tight">:</span><span class="tight">:</span> (Error <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Either l r</code></a>
+                <a href="#encaseEither3_"><code><b>encaseEither3_</b> :: (Error -> l) -> ((a, b, c) -> r) -> a -> b -> c -> Either l r</code></a>
               </li>
               <li>
-                <a href="#eitherToMaybe"><code><b>eitherToMaybe</b> <span class="tight">:</span><span class="tight">:</span> Either a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</code></a>
+                <a href="#eitherToMaybe"><code><b>eitherToMaybe</b> :: Either a b -> Maybe b</code></a>
               </li>
             </ul>
           </li>
@@ -497,31 +498,31 @@
             <a href="#logic">Logic</a>
             <ul>
               <li>
-                <a href="#and"><code><b>and</b> <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#and"><code><b>and</b> :: Boolean -> Boolean -> Boolean</code></a>
               </li>
               <li>
-                <a href="#or"><code><b>or</b> <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#or"><code><b>or</b> :: Boolean -> Boolean -> Boolean</code></a>
               </li>
               <li>
-                <a href="#not"><code><b>not</b> <span class="tight">:</span><span class="tight">:</span> Boolean <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#not"><code><b>not</b> :: Boolean -> Boolean</code></a>
               </li>
               <li>
-                <a href="#complement"><code><b>complement</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#complement"><code><b>complement</b> :: (a -> Boolean) -> a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#ifElse"><code><b>ifElse</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#ifElse"><code><b>ifElse</b> :: (a -> Boolean) -> (a -> b) -> (a -> b) -> a -> b</code></a>
               </li>
               <li>
-                <a href="#when"><code><b>when</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#when"><code><b>when</b> :: (a -> Boolean) -> (a -> a) -> a -> a</code></a>
               </li>
               <li>
-                <a href="#unless"><code><b>unless</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></a>
+                <a href="#unless"><code><b>unless</b> :: (a -> Boolean) -> (a -> a) -> a -> a</code></a>
               </li>
               <li>
-                <a href="#allPass"><code><b>allPass</b> <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#allPass"><code><b>allPass</b> :: Array (a -> Boolean) -> a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#anyPass"><code><b>anyPass</b> <span class="tight">:</span><span class="tight">:</span> Array (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#anyPass"><code><b>anyPass</b> :: Array (a -> Boolean) -> a -> Boolean</code></a>
               </li>
             </ul>
           </li>
@@ -529,43 +530,43 @@
             <a href="#list">List</a>
             <ul>
               <li>
-                <a href="#slice"><code><b>slice</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</code></a>
+                <a href="#slice"><code><b>slice</b> :: Integer -> Integer -> List a -> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#at"><code><b>at</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#at"><code><b>at</b> :: Integer -> List a -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#head"><code><b>head</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#head"><code><b>head</b> :: List a -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#last"><code><b>last</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#last"><code><b>last</b> :: List a -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#tail"><code><b>tail</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</code></a>
+                <a href="#tail"><code><b>tail</b> :: List a -> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#init"><code><b>init</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</code></a>
+                <a href="#init"><code><b>init</b> :: List a -> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#take"><code><b>take</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</code></a>
+                <a href="#take"><code><b>take</b> :: Integer -> List a -> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#takeLast"><code><b>takeLast</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</code></a>
+                <a href="#takeLast"><code><b>takeLast</b> :: Integer -> List a -> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#drop"><code><b>drop</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</code></a>
+                <a href="#drop"><code><b>drop</b> :: Integer -> List a -> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#dropLast"><code><b>dropLast</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (List a)</code></a>
+                <a href="#dropLast"><code><b>dropLast</b> :: Integer -> List a -> Maybe (List a)</code></a>
               </li>
               <li>
-                <a href="#reverse"><code><b>reverse</b> <span class="tight">:</span><span class="tight">:</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a</code></a>
+                <a href="#reverse"><code><b>reverse</b> :: List a -> List a</code></a>
               </li>
               <li>
-                <a href="#indexOf"><code><b>indexOf</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe Integer</code></a>
+                <a href="#indexOf"><code><b>indexOf</b> :: a -> List a -> Maybe Integer</code></a>
               </li>
               <li>
-                <a href="#lastIndexOf"><code><b>lastIndexOf</b> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> List a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe Integer</code></a>
+                <a href="#lastIndexOf"><code><b>lastIndexOf</b> :: a -> List a -> Maybe Integer</code></a>
               </li>
             </ul>
           </li>
@@ -573,40 +574,40 @@
             <a href="#array">Array</a>
             <ul>
               <li>
-                <a href="#append"><code><b>append</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Semigroup (f a)) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></a>
+                <a href="#append"><code><b>append</b> :: (Applicative f, Semigroup (f a)) => a -> f a -> f a</code></a>
               </li>
               <li>
-                <a href="#prepend"><code><b>prepend</b> <span class="tight">:</span><span class="tight">:</span> (Applicative f, Semigroup (f a)) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></a>
+                <a href="#prepend"><code><b>prepend</b> :: (Applicative f, Semigroup (f a)) => a -> f a -> f a</code></a>
               </li>
               <li>
-                <a href="#joinWith"><code><b>joinWith</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#joinWith"><code><b>joinWith</b> :: String -> Array String -> String</code></a>
               </li>
               <li>
-                <a href="#elem"><code><b>elem</b> <span class="tight">:</span><span class="tight">:</span> (Setoid a, Foldable f) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#elem"><code><b>elem</b> :: (Setoid a, Foldable f) => a -> f a -> Boolean</code></a>
               </li>
               <li>
-                <a href="#find"><code><b>find</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe a</code></a>
+                <a href="#find"><code><b>find</b> :: Foldable f => (a -> Boolean) -> f a -> Maybe a</code></a>
               </li>
               <li>
-                <a href="#pluck"><code><b>pluck</b> <span class="tight">:</span><span class="tight">:</span> (Accessible a, Functor f) <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></a>
+                <a href="#pluck"><code><b>pluck</b> :: (Accessible a, Functor f) => String -> f a -> f b</code></a>
               </li>
               <li>
-                <a href="#unfoldr"><code><b>unfoldr</b> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe (Pair a b)) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a</code></a>
+                <a href="#unfoldr"><code><b>unfoldr</b> :: (b -> Maybe (Pair a b)) -> b -> Array a</code></a>
               </li>
               <li>
-                <a href="#range"><code><b>range</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array Integer</code></a>
+                <a href="#range"><code><b>range</b> :: Integer -> Integer -> Array Integer</code></a>
               </li>
               <li>
-                <a href="#groupBy"><code><b>groupBy</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array (Array a)</code></a>
+                <a href="#groupBy"><code><b>groupBy</b> :: (a -> a -> Boolean) -> Array a -> Array (Array a)</code></a>
               </li>
               <li>
-                <a href="#groupBy_"><code><b>groupBy_</b> <span class="tight">:</span><span class="tight">:</span> ((a, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array (Array a)</code></a>
+                <a href="#groupBy_"><code><b>groupBy_</b> :: ((a, a) -> Boolean) -> Array a -> Array (Array a)</code></a>
               </li>
               <li>
-                <a href="#sort"><code><b>sort</b> <span class="tight">:</span><span class="tight">:</span> (Ord a, Applicative m, Foldable m, Monoid (m a)) <span class="arrow">=&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></a>
+                <a href="#sort"><code><b>sort</b> :: (Ord a, Applicative m, Foldable m, Monoid (m a)) => m a -> m a</code></a>
               </li>
               <li>
-                <a href="#sortBy"><code><b>sortBy</b> <span class="tight">:</span><span class="tight">:</span> (Ord b, Applicative m, Foldable m, Monoid (m a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></a>
+                <a href="#sortBy"><code><b>sortBy</b> :: (Ord b, Applicative m, Foldable m, Monoid (m a)) => (a -> b) -> m a -> m a</code></a>
               </li>
             </ul>
           </li>
@@ -614,25 +615,25 @@
             <a href="#object">Object</a>
             <ul>
               <li>
-                <a href="#prop"><code><b>prop</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#prop"><code><b>prop</b> :: Accessible a => String -> a -> b</code></a>
               </li>
               <li>
-                <a href="#props"><code><b>props</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></a>
+                <a href="#props"><code><b>props</b> :: Accessible a => Array String -> a -> b</code></a>
               </li>
               <li>
-                <a href="#get"><code><b>get</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe c</code></a>
+                <a href="#get"><code><b>get</b> :: Accessible a => (b -> Boolean) -> String -> a -> Maybe c</code></a>
               </li>
               <li>
-                <a href="#gets"><code><b>gets</b> <span class="tight">:</span><span class="tight">:</span> Accessible a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe c</code></a>
+                <a href="#gets"><code><b>gets</b> :: Accessible a => (b -> Boolean) -> Array String -> a -> Maybe c</code></a>
               </li>
               <li>
-                <a href="#keys"><code><b>keys</b> <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String</code></a>
+                <a href="#keys"><code><b>keys</b> :: StrMap a -> Array String</code></a>
               </li>
               <li>
-                <a href="#values"><code><b>values</b> <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array a</code></a>
+                <a href="#values"><code><b>values</b> :: StrMap a -> Array a</code></a>
               </li>
               <li>
-                <a href="#pairs"><code><b>pairs</b> <span class="tight">:</span><span class="tight">:</span> StrMap a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array (Pair String a)</code></a>
+                <a href="#pairs"><code><b>pairs</b> :: StrMap a -> Array (Pair String a)</code></a>
               </li>
             </ul>
           </li>
@@ -640,31 +641,31 @@
             <a href="#number">Number</a>
             <ul>
               <li>
-                <a href="#negate"><code><b>negate</b> <span class="tight">:</span><span class="tight">:</span> ValidNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> ValidNumber</code></a>
+                <a href="#negate"><code><b>negate</b> :: ValidNumber -> ValidNumber</code></a>
               </li>
               <li>
-                <a href="#add"><code><b>add</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</code></a>
+                <a href="#add"><code><b>add</b> :: FiniteNumber -> FiniteNumber -> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#sum"><code><b>sum</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</code></a>
+                <a href="#sum"><code><b>sum</b> :: Foldable f => f FiniteNumber -> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#sub"><code><b>sub</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber)</code></a>
+                <a href="#sub"><code><b>sub</b> :: FiniteNumber -> (FiniteNumber -> FiniteNumber)</code></a>
               </li>
               <li>
-                <a href="#sub_"><code><b>sub_</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</code></a>
+                <a href="#sub_"><code><b>sub_</b> :: FiniteNumber -> FiniteNumber -> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#mult"><code><b>mult</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</code></a>
+                <a href="#mult"><code><b>mult</b> :: FiniteNumber -> FiniteNumber -> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#product"><code><b>product</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</code></a>
+                <a href="#product"><code><b>product</b> :: Foldable f => f FiniteNumber -> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#div"><code><b>div</b> <span class="tight">:</span><span class="tight">:</span> FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> NonZeroFiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> FiniteNumber</code></a>
+                <a href="#div"><code><b>div</b> :: FiniteNumber -> NonZeroFiniteNumber -> FiniteNumber</code></a>
               </li>
               <li>
-                <a href="#mean"><code><b>mean</b> <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f FiniteNumber <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe FiniteNumber</code></a>
+                <a href="#mean"><code><b>mean</b> :: Foldable f => f FiniteNumber -> Maybe FiniteNumber</code></a>
               </li>
             </ul>
           </li>
@@ -672,10 +673,10 @@
             <a href="#integer">Integer</a>
             <ul>
               <li>
-                <a href="#even"><code><b>even</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#even"><code><b>even</b> :: Integer -> Boolean</code></a>
               </li>
               <li>
-                <a href="#odd"><code><b>odd</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#odd"><code><b>odd</b> :: Integer -> Boolean</code></a>
               </li>
             </ul>
           </li>
@@ -683,16 +684,16 @@
             <a href="#parse">Parse</a>
             <ul>
               <li>
-                <a href="#parseDate"><code><b>parseDate</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe Date</code></a>
+                <a href="#parseDate"><code><b>parseDate</b> :: String -> Maybe Date</code></a>
               </li>
               <li>
-                <a href="#parseFloat"><code><b>parseFloat</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe Number</code></a>
+                <a href="#parseFloat"><code><b>parseFloat</b> :: String -> Maybe Number</code></a>
               </li>
               <li>
-                <a href="#parseInt"><code><b>parseInt</b> <span class="tight">:</span><span class="tight">:</span> Integer <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe Integer</code></a>
+                <a href="#parseInt"><code><b>parseInt</b> :: Integer -> String -> Maybe Integer</code></a>
               </li>
               <li>
-                <a href="#parseJson"><code><b>parseJson</b> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe b</code></a>
+                <a href="#parseJson"><code><b>parseJson</b> :: (a -> Boolean) -> String -> Maybe b</code></a>
               </li>
             </ul>
           </li>
@@ -700,19 +701,19 @@
             <a href="#regexp">RegExp</a>
             <ul>
               <li>
-                <a href="#regex"><code><b>regex</b> <span class="tight">:</span><span class="tight">:</span> RegexFlags <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> RegExp</code></a>
+                <a href="#regex"><code><b>regex</b> :: RegexFlags -> String -> RegExp</code></a>
               </li>
               <li>
-                <a href="#regexEscape"><code><b>regexEscape</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#regexEscape"><code><b>regexEscape</b> :: String -> String</code></a>
               </li>
               <li>
-                <a href="#test"><code><b>test</b> <span class="tight">:</span><span class="tight">:</span> RegExp <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Boolean</code></a>
+                <a href="#test"><code><b>test</b> :: RegExp -> String -> Boolean</code></a>
               </li>
               <li>
-                <a href="#match"><code><b>match</b> <span class="tight">:</span><span class="tight">:</span> NonGlobalRegExp <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</code></a>
+                <a href="#match"><code><b>match</b> :: NonGlobalRegExp -> String -> Maybe { match :: String, groups :: Array (Maybe String) }</code></a>
               </li>
               <li>
-                <a href="#matchAll"><code><b>matchAll</b> <span class="tight">:</span><span class="tight">:</span> GlobalRegExp <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array { match <span class="tight">:</span><span class="tight">:</span> String, groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String) }</code></a>
+                <a href="#matchAll"><code><b>matchAll</b> :: GlobalRegExp -> String -> Array { match :: String, groups :: Array (Maybe String) }</code></a>
               </li>
             </ul>
           </li>
@@ -720,37 +721,37 @@
             <a href="#string">String</a>
             <ul>
               <li>
-                <a href="#toUpper"><code><b>toUpper</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#toUpper"><code><b>toUpper</b> :: String -> String</code></a>
               </li>
               <li>
-                <a href="#toLower"><code><b>toLower</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#toLower"><code><b>toLower</b> :: String -> String</code></a>
               </li>
               <li>
-                <a href="#trim"><code><b>trim</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#trim"><code><b>trim</b> :: String -> String</code></a>
               </li>
               <li>
-                <a href="#stripPrefix"><code><b>stripPrefix</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe String</code></a>
+                <a href="#stripPrefix"><code><b>stripPrefix</b> :: String -> String -> Maybe String</code></a>
               </li>
               <li>
-                <a href="#stripSuffix"><code><b>stripSuffix</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Maybe String</code></a>
+                <a href="#stripSuffix"><code><b>stripSuffix</b> :: String -> String -> Maybe String</code></a>
               </li>
               <li>
-                <a href="#words"><code><b>words</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String</code></a>
+                <a href="#words"><code><b>words</b> :: String -> Array String</code></a>
               </li>
               <li>
-                <a href="#unwords"><code><b>unwords</b> <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#unwords"><code><b>unwords</b> :: Array String -> String</code></a>
               </li>
               <li>
-                <a href="#lines"><code><b>lines</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String</code></a>
+                <a href="#lines"><code><b>lines</b> :: String -> Array String</code></a>
               </li>
               <li>
-                <a href="#unlines"><code><b>unlines</b> <span class="tight">:</span><span class="tight">:</span> Array String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String</code></a>
+                <a href="#unlines"><code><b>unlines</b> :: Array String -> String</code></a>
               </li>
               <li>
-                <a href="#splitOn"><code><b>splitOn</b> <span class="tight">:</span><span class="tight">:</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String</code></a>
+                <a href="#splitOn"><code><b>splitOn</b> :: String -> String -> Array String</code></a>
               </li>
               <li>
-                <a href="#splitOnRegex"><code><b>splitOnRegex</b> <span class="tight">:</span><span class="tight">:</span> GlobalRegExp <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> String <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Array String</code></a>
+                <a href="#splitOnRegex"><code><b>splitOnRegex</b> :: GlobalRegExp -> String -> Array String</code></a>
               </li>
             </ul>
           </li>
@@ -799,7 +800,7 @@ to mean &quot;is a member of&quot;, so one could write:</p>
 [1, 2, 3] :: Array Number
 </code></pre><p>An identifier may appear to the left of the double colon:</p>
 <pre><code>Math.PI :: Number
-</code></pre><p>The arrow (<code><span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span></code>) is used to express a function&#39;s type:</p>
+</code></pre><p>The arrow (<code>-&gt;</code>) is used to express a function&#39;s type:</p>
 <pre><code>Math.abs :: Number -&gt; Number
 </code></pre><p>That states that <code>Math.abs</code> is a unary function which takes an argument
 of type <code>Number</code> and returns a value of type <code>Number</code>.</p>
@@ -817,18 +818,18 @@ The same applies for each other type variable. For the function above, the
 types with which <code>a</code> and <code>b</code> are replaced may be different, but needn&#39;t be.</p>
 <p>Since all Sanctuary functions are curried (they accept their arguments
 one at a time), a binary function is represented as a unary function which
-returns a unary function: <code>* <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> * <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> *</code>. This aligns neatly with Haskell,
+returns a unary function: <code>* -&gt; * -&gt; *</code>. This aligns neatly with Haskell,
 which uses curried functions exclusively. In JavaScript, though, we may
 wish to represent the types of functions with arities less than or greater
-than one. The general form is <code>(&lt;input-types&gt;) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> &lt;output-type&gt;</code>, where
+than one. The general form is <code>(&lt;input-types&gt;) -&gt; &lt;output-type&gt;</code>, where
 <code>&lt;input-types&gt;</code> comprises zero or more comma–space (<code>, </code>)
 -separated type representations:</p>
 <ul>
-<li><code>() <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> String</code></li>
-<li><code>(a, b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code></li>
-<li><code>(a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> d</code></li>
+<li><code>() -&gt; String</code></li>
+<li><code>(a, b) -&gt; a</code></li>
+<li><code>(a, b, c) -&gt; d</code></li>
 </ul>
-<p><code>Number <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Number</code> can thus be seen as shorthand for <code>(Number) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Number</code>.</p>
+<p><code>Number -&gt; Number</code> can thus be seen as shorthand for <code>(Number) -&gt; Number</code>.</p>
 <p>The question mark (<code>?</code>) is used to represent types which include <code>null</code>
 and <code>undefined</code> as members. <code>String?</code>, for example, represents the type
 comprising <code>null</code>, <code>undefined</code>, and all strings.</p>
@@ -841,20 +842,20 @@ to the <em>methods</em> provided by Sanctuary&#39;s types. In <code>x.map(y)</co
 the <code>map</code> method takes an implicit argument <code>x</code> in addition to the explicit
 argument <code>y</code>. The type of the value upon which a method is invoked appears
 at the beginning of the signature, separated from the arguments and return
-value by a squiggly arrow (<code><span class="arrow">~&gt;</span></code>). The type of the <code>map</code> method of the Maybe
-type is written <code>Maybe a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Maybe b</code>. One could read this as:</p>
+value by a squiggly arrow (<code>~&gt;</code>). The type of the <code>map</code> method of the Maybe
+type is written <code>Maybe a ~&gt; (a -&gt; b) -&gt; Maybe b</code>. One could read this as:</p>
 <p><em>When the <code>map</code> method is invoked on a value of type <code>Maybe a</code>
-(for any type <code>a</code>) with an argument of type <code>a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b</code> (for any type <code>b</code>),
+(for any type <code>a</code>) with an argument of type <code>a -&gt; b</code> (for any type <code>b</code>),
 it returns a value of type <code>Maybe b</code>.</em></p>
 <p>The squiggly arrow is also used when representing non-function properties.
-<code>Maybe a <span class="arrow">~&gt;</span> Boolean</code>, for example, represents a Boolean property of a value
+<code>Maybe a ~&gt; Boolean</code>, for example, represents a Boolean property of a value
 of type <code>Maybe a</code>.</p>
 <p>Sanctuary supports type classes: constraints on type variables. Whereas
-<code>a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a</code> implicitly supports every type, <code>Functor f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span>
+<code>a -&gt; a</code> implicitly supports every type, <code>Functor f =&gt; (a -&gt; b) -&gt; f a -&gt;
 f b</code> requires that <code>f</code> be a type which satisfies the requirements of the
 Functor type class. Type-class constraints appear at the beginning of a
 type signature, separated from the rest of the signature by a fat arrow
-(<code><span class="arrow">=&gt;</span></code>).</p>
+(<code>=&gt;</code>).</p>
 <a class="pilcrow h3" href="#accessible-pseudotype">¶</a>
 <h3 id="accessible-pseudotype">Accessible pseudotype</h3>
 <p>What is the type of values which support property access? In other words,
@@ -871,7 +872,7 @@ Sanctuary&#39;s run-time type checking asserts that a valid Number value is
 provided wherever an Integer value is required.</p>
 <a class="pilcrow h3" href="#type-representatives">¶</a>
 <h3 id="type-representatives">Type representatives</h3>
-<p>What is the type of <code>Number</code>? One answer is <code>a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Number</code>, since it&#39;s a
+<p>What is the type of <code>Number</code>? One answer is <code>a -&gt; Number</code>, since it&#39;s a
 function which takes an argument of any type and returns a Number value.
 When provided as the first argument to <a href="#is"><code>is</code></a>, though, <code>Number</code> is
 really the value-level representative of the Number type.</p>
@@ -925,7 +926,7 @@ const S = create({checkTypes, env});
 <a class="pilcrow h2" href="#api">¶</a>
 <h2 id="api">API</h2>
 <a class="pilcrow h4" href="#create">¶</a>
-<h4 id="create"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L381">create</a> <span class="tight">:</span><span class="tight">:</span> { checkTypes <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>, env <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a> } <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> Module</code></h4>
+<h4 id="create"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L381">create</a> :: { checkTypes :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>, env :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a> } -> Module</code></h4>
 
 <p>Takes an options record and returns a Sanctuary module. <code>checkTypes</code>
 specifies whether to enable type checking. The module&#39;s polymorphic
@@ -971,7 +972,7 @@ S.map(S.sub(1), Identity(43));
 </code></pre>
 <p>See also <a href="#env"><code>env</code></a>.</p>
 <a class="pilcrow h4" href="#env">¶</a>
-<h4 id="env"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L437">env</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a></code></h4>
+<h4 id="env"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L437">env</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a></code></h4>
 
 <p>The default environment, which may be used as is or as the basis of a
 custom environment in conjunction with <a href="#create"><code>create</code></a>.</p>
@@ -981,7 +982,7 @@ custom environment in conjunction with <a href="#create"><code>create</code></a>
 In many cases one can define a more specific function in terms of
 a more general one simply by applying the more general function to
 some (but not all) of its arguments. For example, one could define
-<code>sum <span class="tight">:</span><span class="tight">:</span> Foldable f <span class="arrow">=&gt;</span> f Number <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Number</code> as <code>S.reduce(S.add, 0)</code>.</p>
+<code>sum :: Foldable f =&gt; f Number -&gt; Number</code> as <code>S.reduce(S.add, 0)</code>.</p>
 <p>In some cases, though, there are multiple orders in which one may
 wish to provide a function&#39;s arguments. <code>S.concat(&#39;prefix&#39;)</code> is a
 function which prefixes its argument, but how would one define a
@@ -996,7 +997,7 @@ The following are all equivalent (<code>_</code> represents the placeholder):</p
 <li><code>f(_, _, z)(_, y)(x)</code></li>
 </ul>
 <a class="pilcrow h4" href="#__">¶</a>
-<h4 id="__"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L467">__</a> <span class="tight">:</span><span class="tight">:</span> Placeholder</code></h4>
+<h4 id="__"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L467">__</a> :: Placeholder</code></h4>
 
 <p>The special <a href="#placeholder">placeholder</a> value.</p>
 <div class="examples">
@@ -1013,7 +1014,7 @@ The following are all equivalent (<code>_</code> represents the placeholder):</p
 <a class="pilcrow h3" href="#classify">¶</a>
 <h3 id="classify">Classify</h3>
 <a class="pilcrow h4" href="#type">¶</a>
-<h4 id="type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L482">type</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Any">Any</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> { namespace <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>, name <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>, version <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> }</code></h4>
+<h4 id="type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L482">type</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Any">Any</a> -> { namespace :: <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>, name :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>, version :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> }</code></h4>
 
 <p>Returns the result of parsing the <a href="https://github.com/sanctuary-js/sanctuary-type-identifiers/tree/v2.0.1">type identifier</a> of the given value.</p>
 <div class="examples">
@@ -1028,7 +1029,7 @@ The following are all equivalent (<code>_</code> represents the placeholder):</p
 </div>
 
 <a class="pilcrow h4" href="#is">¶</a>
-<h4 id="is"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L506">is</a> <span class="tight">:</span><span class="tight">:</span> <a href="#type-representatives">TypeRep</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Any">Any</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="is"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L506">is</a> :: <a href="#type-representatives">TypeRep</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Any">Any</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Takes a <a href="#type-representatives">type representative</a> and a value of
 any type and returns <code>true</code> if the given value is of the specified
@@ -1051,7 +1052,7 @@ type; <code>false</code> otherwise. Subtyping is not respected.</p>
 <a class="pilcrow h3" href="#showable">¶</a>
 <h3 id="showable">Showable</h3>
 <a class="pilcrow h4" href="#toString">¶</a>
-<h4 id="toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L535">toString</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Any">Any</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L535">toString</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Any">Any</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Alias of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#toString"><code>Z.toString</code></a>.</p>
 <div class="examples">
@@ -1077,7 +1078,7 @@ type; <code>false</code> otherwise. Subtyping is not respected.</p>
 <h3 id="fantasy-land">Fantasy Land</h3>
 <p>Sanctuary is compatible with the <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0">Fantasy Land</a> specification.</p>
 <a class="pilcrow h4" href="#equals">¶</a>
-<h4 id="equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L558">equals</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L558">equals</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a => a -> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#equals"><code>Z.equals</code></a> which requires two arguments of the
 same type.</p>
@@ -1104,7 +1105,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#lt">¶</a>
-<h4 id="lt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L582">lt</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>)</code></h4>
+<h4 id="lt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L582">lt</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => a -> (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>)</code></h4>
 
 <p>Flipped version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lt"><code>Z.lt</code></a> intended for partial application.</p>
 <p>See also <a href="#lt_"><code>lt_</code></a>.</p>
@@ -1116,7 +1117,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#lt_">¶</a>
-<h4 id="lt_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L594">lt_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="lt_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L594">lt_</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => a -> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lt"><code>Z.lt</code></a>.</p>
 <p>See also <a href="#lt"><code>lt</code></a>.</p>
@@ -1136,7 +1137,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#lte">¶</a>
-<h4 id="lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L612">lte</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>)</code></h4>
+<h4 id="lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L612">lte</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => a -> (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>)</code></h4>
 
 <p>Flipped version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a> intended for partial application.</p>
 <p>See also <a href="#lte_"><code>lte_</code></a>.</p>
@@ -1148,7 +1149,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#lte_">¶</a>
-<h4 id="lte_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L624">lte_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="lte_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L624">lte_</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => a -> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a>.</p>
 <p>See also <a href="#lte"><code>lte</code></a>.</p>
@@ -1168,7 +1169,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#gt">¶</a>
-<h4 id="gt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L642">gt</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>)</code></h4>
+<h4 id="gt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L642">gt</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => a -> (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>)</code></h4>
 
 <p>Flipped version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#gt"><code>Z.gt</code></a> intended for partial application.</p>
 <p>See also <a href="#gt_"><code>gt_</code></a>.</p>
@@ -1180,7 +1181,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#gt_">¶</a>
-<h4 id="gt_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L654">gt_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="gt_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L654">gt_</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => a -> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#gt"><code>Z.gt</code></a>.</p>
 <p>See also <a href="#gt"><code>gt</code></a>.</p>
@@ -1200,7 +1201,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#gte">¶</a>
-<h4 id="gte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L672">gte</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>)</code></h4>
+<h4 id="gte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L672">gte</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => a -> (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>)</code></h4>
 
 <p>Flipped version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#gte"><code>Z.gte</code></a> intended for partial application.</p>
 <p>See also <a href="#gte_"><code>gte_</code></a>.</p>
@@ -1212,7 +1213,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#gte_">¶</a>
-<h4 id="gte_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L684">gte_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="gte_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L684">gte_</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => a -> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#gte"><code>Z.gte</code></a>.</p>
 <p>See also <a href="#gte"><code>gte</code></a>.</p>
@@ -1232,7 +1233,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#min">¶</a>
-<h4 id="min"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L702">min</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="min"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L702">min</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => a -> a -> a</code></h4>
 
 <p>Returns the smaller of its two arguments (according to <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a>).</p>
 <p>See also <a href="#max"><code>max</code></a>.</p>
@@ -1252,7 +1253,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#max">¶</a>
-<h4 id="max"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L723">max</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="max"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L723">max</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => a -> a -> a</code></h4>
 
 <p>Returns the larger of its two arguments (according to <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a>).</p>
 <p>See also <a href="#min"><code>min</code></a>.</p>
@@ -1272,7 +1273,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#id">¶</a>
-<h4 id="id"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L744">id</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Category">Category</a> c <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
+<h4 id="id"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L744">id</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Category">Category</a> c => <a href="#type-representatives">TypeRep</a> c -> c</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#id"><code>Z.id</code></a>.</p>
 <div class="examples">
@@ -1283,7 +1284,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#concat">¶</a>
-<h4 id="concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L754">concat</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> a <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L754">concat</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> a => a -> a -> a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#concat"><code>Z.concat</code></a>.</p>
 <div class="examples">
@@ -1306,7 +1307,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#empty">¶</a>
-<h4 id="empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L773">empty</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> a <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L773">empty</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> a => <a href="#type-representatives">TypeRep</a> a -> a</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#empty"><code>Z.empty</code></a>.</p>
 <div class="examples">
@@ -1325,7 +1326,7 @@ module&#39;s <code>equals</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#map">¶</a>
-<h4 id="map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L789">map</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Functor">Functor</a> f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></h4>
+<h4 id="map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L789">map</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Functor">Functor</a> f => (a -> b) -> f a -> f b</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#map"><code>Z.map</code></a>.</p>
 <div class="examples">
@@ -1347,7 +1348,7 @@ module&#39;s <code>equals</code> function.</p>
   </form>
 </div>
 
-<p>Replacing <code>Functor f <span class="arrow">=&gt;</span> f</code> with <code>Function x</code> produces the B combinator
+<p>Replacing <code>Functor f =&gt; f</code> with <code>Function x</code> produces the B combinator
 from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 <pre><code>Functor f =&gt; (a -&gt; b) -&gt; f a -&gt; f b
 (a -&gt; b) -&gt; Function x a -&gt; Function x b
@@ -1363,7 +1364,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#bimap">¶</a>
-<h4 id="bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L823">bimap</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Bifunctor">Bifunctor</a> f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b d</code></h4>
+<h4 id="bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L823">bimap</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Bifunctor">Bifunctor</a> f => (a -> b) -> (c -> d) -> f a c -> f b d</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#bimap"><code>Z.bimap</code></a>.</p>
 <div class="examples">
@@ -1378,7 +1379,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#promap">¶</a>
-<h4 id="promap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L840">promap</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Profunctor">Profunctor</a> p <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> p b c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> p a d</code></h4>
+<h4 id="promap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L840">promap</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Profunctor">Profunctor</a> p => (a -> b) -> (c -> d) -> p b c -> p a d</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#promap"><code>Z.promap</code></a>.</p>
 <div class="examples">
@@ -1389,7 +1390,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#alt">¶</a>
-<h4 id="alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L854">alt</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alt">Alt</a> f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
+<h4 id="alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L854">alt</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alt">Alt</a> f => f a -> f a -> f a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#alt"><code>Z.alt</code></a>.</p>
 <div class="examples">
@@ -1412,7 +1413,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#zero">¶</a>
-<h4 id="zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L873">zero</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Plus">Plus</a> f <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
+<h4 id="zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L873">zero</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Plus">Plus</a> f => <a href="#type-representatives">TypeRep</a> f -> f a</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#zero"><code>Z.zero</code></a>.</p>
 <div class="examples">
@@ -1431,7 +1432,7 @@ from combinatory logic (i.e. <a href="#compose"><code>compose</code></a>):</p>
 </div>
 
 <a class="pilcrow h4" href="#reduce">¶</a>
-<h4 id="reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L890">reduce</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L890">reduce</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f => (b -> a -> b) -> b -> f a -> b</code></h4>
 
 <p>Takes a curried binary function, an initial value, and a <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#foldable">Foldable</a>,
 and applies the function to the initial value and the Foldable&#39;s first
@@ -1453,11 +1454,11 @@ otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#reduce_">¶</a>
-<h4 id="reduce_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L915">reduce_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="reduce_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L915">reduce_</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f => ((b, a) -> b) -> b -> f a -> b</code></h4>
 
 <p>Variant of <a href="#reduce"><code>reduce</code></a> which takes an uncurried binary function.</p>
 <a class="pilcrow h4" href="#traverse">¶</a>
-<h4 id="traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L924">traverse</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Traversable">Traversable</a> t) <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> t a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (t b)</code></h4>
+<h4 id="traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L924">traverse</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Traversable">Traversable</a> t) => <a href="#type-representatives">TypeRep</a> f -> (a -> f b) -> t a -> f (t b)</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#traverse"><code>Z.traverse</code></a>.</p>
 <div class="examples">
@@ -1488,7 +1489,7 @@ otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sequence">¶</a>
-<h4 id="sequence"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L953">sequence</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Traversable">Traversable</a> t) <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> t (f a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (t a)</code></h4>
+<h4 id="sequence"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L953">sequence</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Traversable">Traversable</a> t) => <a href="#type-representatives">TypeRep</a> f -> t (f a) -> f (t a)</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#sequence"><code>Z.sequence</code></a>.</p>
 <div class="examples">
@@ -1515,7 +1516,7 @@ otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#ap">¶</a>
-<h4 id="ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L979">ap</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f <span class="arrow">=&gt;</span> f (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></h4>
+<h4 id="ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L979">ap</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f => f (a -> b) -> f a -> f b</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#ap"><code>Z.ap</code></a>.</p>
 <div class="examples">
@@ -1533,7 +1534,7 @@ otherwise.</p>
   </form>
 </div>
 
-<p>Replacing <code>Apply f <span class="arrow">=&gt;</span> f</code> with <code>Function x</code> produces the S combinator
+<p>Replacing <code>Apply f =&gt; f</code> with <code>Function x</code> produces the S combinator
 from combinatory logic:</p>
 <pre><code>Apply f =&gt; f (a -&gt; b) -&gt; f a -&gt; f b
 Function x (a -&gt; b) -&gt; Function x a -&gt; Function x b
@@ -1549,7 +1550,7 @@ Function a (b -&gt; c) -&gt; Function a b -&gt; Function a c
 </div>
 
 <a class="pilcrow h4" href="#lift2">¶</a>
-<h4 id="lift2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1014">lift2</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c</code></h4>
+<h4 id="lift2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1014">lift2</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f => (a -> b -> c) -> f a -> f b -> f c</code></h4>
 
 <p>Promotes a curried binary function to a function which operates on two
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#apply">Apply</a>s.</p>
@@ -1573,7 +1574,7 @@ Function a (b -&gt; c) -&gt; Function a b -&gt; Function a c
 </div>
 
 <a class="pilcrow h4" href="#lift3">¶</a>
-<h4 id="lift3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1035">lift3</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f d</code></h4>
+<h4 id="lift3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1035">lift3</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d</code></h4>
 
 <p>Promotes a curried ternary function to a function which operates on three
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#apply">Apply</a>s.</p>
@@ -1589,7 +1590,7 @@ Function a (b -&gt; c) -&gt; Function a b -&gt; Function a c
 </div>
 
 <a class="pilcrow h4" href="#apFirst">¶</a>
-<h4 id="apFirst"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1053">apFirst</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
+<h4 id="apFirst"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1053">apFirst</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f => f a -> f b -> f a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#apFirst"><code>Z.apFirst</code></a>. Combines two effectful actions,
 keeping only the result of the first. Equivalent to Haskell&#39;s <code>(&lt;*)</code>
@@ -1607,7 +1608,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#apSecond">¶</a>
-<h4 id="apSecond"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1070">apSecond</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f <span class="arrow">=&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></h4>
+<h4 id="apSecond"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1070">apSecond</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Apply">Apply</a> f => f a -> f b -> f b</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#apSecond"><code>Z.apSecond</code></a>. Combines two effectful actions,
 keeping only the result of the second. Equivalent to Haskell&#39;s <code>(*&gt;)</code>
@@ -1625,7 +1626,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#of">¶</a>
-<h4 id="of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1087">of</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> f <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
+<h4 id="of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1087">of</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f => <a href="#type-representatives">TypeRep</a> f -> a -> f a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#of"><code>Z.of</code></a>.</p>
 <div class="examples">
@@ -1648,7 +1649,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#chain">¶</a>
-<h4 id="chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1110">chain</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Chain">Chain</a> m <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b</code></h4>
+<h4 id="chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1110">chain</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Chain">Chain</a> m => (a -> m b) -> m a -> m b</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#chain"><code>Z.chain</code></a>.</p>
 <div class="examples">
@@ -1671,7 +1672,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#join">¶</a>
-<h4 id="join"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1129">join</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Chain">Chain</a> m <span class="arrow">=&gt;</span> m (m a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></h4>
+<h4 id="join"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1129">join</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Chain">Chain</a> m => m (m a) -> m a</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#join"><code>Z.join</code></a>.
 Removes one level of nesting from a nested monadic structure.</p>
@@ -1690,7 +1691,7 @@ Removes one level of nesting from a nested monadic structure.</p>
   </form>
 </div>
 
-<p>Replacing <code>Chain m <span class="arrow">=&gt;</span> m</code> with <code>Function x</code> produces the W combinator
+<p>Replacing <code>Chain m =&gt; m</code> with <code>Function x</code> produces the W combinator
 from combinatory logic:</p>
 <pre><code>Chain m =&gt; m (m a) -&gt; m a
 Function x (Function x a) -&gt; Function x a
@@ -1703,7 +1704,7 @@ Function x (Function x a) -&gt; Function x a
 </div>
 
 <a class="pilcrow h4" href="#chainRec">¶</a>
-<h4 id="chainRec"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1158">chainRec</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#ChainRec">ChainRec</a> m <span class="arrow">=&gt;</span> <a href="#type-representatives">TypeRep</a> m <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m (<a href="#EitherType">Either</a> a b)) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m b</code></h4>
+<h4 id="chainRec"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1158">chainRec</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#ChainRec">ChainRec</a> m => <a href="#type-representatives">TypeRep</a> m -> (a -> m (<a href="#EitherType">Either</a> a b)) -> a -> m b</code></h4>
 
 <p>Performs a <a href="#chain"><code>chain</code></a>-like computation with constant stack usage.
 Similar to <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#chainRec"><code>Z.chainRec</code></a>, but curried and more convenient due to the
@@ -1716,7 +1717,7 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#extend">¶</a>
-<h4 id="extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1183">extend</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Extend">Extend</a> w <span class="arrow">=&gt;</span> (w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> w b</code></h4>
+<h4 id="extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1183">extend</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Extend">Extend</a> w => (w a -> b) -> w a -> w b</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#extend"><code>Z.extend</code></a>.</p>
 <div class="examples">
@@ -1727,11 +1728,11 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#extract">¶</a>
-<h4 id="extract"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1194">extract</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Comonad">Comonad</a> w <span class="arrow">=&gt;</span> w a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="extract"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1194">extract</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Comonad">Comonad</a> w => w a -> a</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#extract"><code>Z.extract</code></a>.</p>
 <a class="pilcrow h4" href="#contramap">¶</a>
-<h4 id="contramap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1200">contramap</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Contravariant">Contravariant</a> f <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></h4>
+<h4 id="contramap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1200">contramap</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Contravariant">Contravariant</a> f => (b -> a) -> f a -> f b</code></h4>
 
 <p><a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1">Type-safe</a> version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#contramap"><code>Z.contramap</code></a>.</p>
 <div class="examples">
@@ -1742,7 +1743,7 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#filter">¶</a>
-<h4 id="filter"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1214">filter</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> (f a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
+<h4 id="filter"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1214">filter</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> (f a)) => (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> f a -> f a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#filter"><code>Z.filter</code></a>.</p>
 <p>See also <a href="#filterM"><code>filterM</code></a>.</p>
@@ -1754,7 +1755,7 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#filterM">¶</a>
-<h4 id="filterM"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1230">filterM</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alternative">Alternative</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monad">Monad</a> m) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></h4>
+<h4 id="filterM"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1230">filterM</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alternative">Alternative</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monad">Monad</a> m) => (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> m a -> m a</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#filterM"><code>Z.filterM</code></a>.</p>
 <p>See also <a href="#filter"><code>filter</code></a>.</p>
@@ -1774,7 +1775,7 @@ use of the Either type to indicate completion (via a Right).</p>
 </div>
 
 <a class="pilcrow h4" href="#takeWhile">¶</a>
-<h4 id="takeWhile"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1252">takeWhile</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alternative">Alternative</a> f) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
+<h4 id="takeWhile"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1252">takeWhile</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alternative">Alternative</a> f) => (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> f a -> f a</code></h4>
 
 <p>Discards the first inner value which does not satisfy the predicate, and
 all subsequent inner values.</p>
@@ -1790,7 +1791,7 @@ all subsequent inner values.</p>
 </div>
 
 <a class="pilcrow h4" href="#dropWhile">¶</a>
-<h4 id="dropWhile"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1284">dropWhile</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alternative">Alternative</a> f) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
+<h4 id="dropWhile"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1284">dropWhile</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Alternative">Alternative</a> f) => (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> f a -> f a</code></h4>
 
 <p>Retains the first inner value which does not satisfy the predicate, and
 all subsequent inner values.</p>
@@ -1808,7 +1809,7 @@ all subsequent inner values.</p>
 <a class="pilcrow h3" href="#combinator">¶</a>
 <h3 id="combinator">Combinator</h3>
 <a class="pilcrow h4" href="#I">¶</a>
-<h4 id="I"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1318">I</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="I"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1318">I</a> :: a -> a</code></h4>
 
 <p>The I combinator. Returns its argument. Equivalent to Haskell&#39;s <code>id</code>
 function.</p>
@@ -1820,7 +1821,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#K">¶</a>
-<h4 id="K"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1332">K</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="K"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1332">K</a> :: a -> b -> a</code></h4>
 
 <p>The K combinator. Takes two values and returns the first. Equivalent to
 Haskell&#39;s <code>const</code> function.</p>
@@ -1836,7 +1837,7 @@ Haskell&#39;s <code>const</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#A">¶</a>
-<h4 id="A"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1349">A</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="A"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1349">A</a> :: (a -> b) -> a -> b</code></h4>
 
 <p>The A combinator. Takes a function and a value, and returns the result
 of applying the function to the value. Equivalent to Haskell&#39;s <code>($)</code>
@@ -1853,7 +1854,7 @@ function.</p>
 </div>
 
 <a class="pilcrow h4" href="#T">¶</a>
-<h4 id="T"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1367">T</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="T"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1367">T</a> :: a -> (a -> b) -> b</code></h4>
 
 <p>The T (<a href="https://github.com/raganwald-deprecated/homoiconic/blob/master/2008-10-30/thrush.markdown">thrush</a>) combinator. Takes a value and a function, and returns
 the result of applying the function to the value. Equivalent to Haskell&#39;s
@@ -1872,7 +1873,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 <a class="pilcrow h3" href="#function">¶</a>
 <h3 id="function">Function</h3>
 <a class="pilcrow h4" href="#curry2">¶</a>
-<h4 id="curry2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1387">curry2</a> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
+<h4 id="curry2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1387">curry2</a> :: ((a, b) -> c) -> a -> b -> c</code></h4>
 
 <p>Curries the given binary function.</p>
 <div class="examples">
@@ -1887,7 +1888,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#curry3">¶</a>
-<h4 id="curry3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1407">curry3</a> <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d</code></h4>
+<h4 id="curry3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1407">curry3</a> :: ((a, b, c) -> d) -> a -> b -> c -> d</code></h4>
 
 <p>Curries the given ternary function.</p>
 <div class="examples">
@@ -1906,7 +1907,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#curry4">¶</a>
-<h4 id="curry4"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1432">curry4</a> <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e</code></h4>
+<h4 id="curry4"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1432">curry4</a> :: ((a, b, c, d) -> e) -> a -> b -> c -> d -> e</code></h4>
 
 <p>Curries the given quaternary function.</p>
 <div class="examples">
@@ -1925,7 +1926,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#curry5">¶</a>
-<h4 id="curry5"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1457">curry5</a> <span class="tight">:</span><span class="tight">:</span> ((a, b, c, d, e) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> e <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f</code></h4>
+<h4 id="curry5"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1457">curry5</a> :: ((a, b, c, d, e) -> f) -> a -> b -> c -> d -> e -> f</code></h4>
 
 <p>Curries the given quinary function.</p>
 <div class="examples">
@@ -1944,7 +1945,7 @@ the result of applying the function to the value. Equivalent to Haskell&#39;s
 </div>
 
 <a class="pilcrow h4" href="#flip">¶</a>
-<h4 id="flip"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1486">flip</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
+<h4 id="flip"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1486">flip</a> :: (a -> b -> c) -> b -> a -> c</code></h4>
 
 <p>Takes a curried binary function and two values, and returns the
 result of applying the function to the values in reverse order.</p>
@@ -1957,13 +1958,13 @@ result of applying the function to the values in reverse order.</p>
 </div>
 
 <a class="pilcrow h4" href="#flip_">¶</a>
-<h4 id="flip_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1502">flip_</a> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
+<h4 id="flip_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1502">flip_</a> :: ((a, b) -> c) -> b -> a -> c</code></h4>
 
 <p>Variant of <a href="#flip"><code>flip</code></a> which takes an uncurried binary function.</p>
 <a class="pilcrow h3" href="#composition">¶</a>
 <h3 id="composition">Composition</h3>
 <a class="pilcrow h4" href="#compose">¶</a>
-<h4 id="compose"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1512">compose</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroupoid">Semigroupoid</a> s <span class="arrow">=&gt;</span> s b c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> s a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> s a c</code></h4>
+<h4 id="compose"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1512">compose</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroupoid">Semigroupoid</a> s => s b c -> s a b -> s a c</code></h4>
 
 <p>Curried version of <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#compose"><code>Z.compose</code></a>.</p>
 <p>When specialized to Function, <code>compose</code> composes two unary functions,
@@ -1979,7 +1980,7 @@ with any <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#semigr
 </div>
 
 <a class="pilcrow h4" href="#pipe">¶</a>
-<h4 id="pipe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1534">pipe</a> <span class="tight">:</span><span class="tight">:</span> [(a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b), (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c), <span class="tight">.</span><span class="tight">.</span><span class="tight">.</span>, (m <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> n)] <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> n</code></h4>
+<h4 id="pipe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1534">pipe</a> :: [(a -> b), (b -> c), ..., (m -> n)] -> a -> n</code></h4>
 
 <p>Takes an array of functions assumed to be unary and a value of any type,
 and returns the result of applying the sequence of transformations to
@@ -1994,7 +1995,7 @@ of functions. <code>pipe([f, g, h], x)</code> is equivalent to <code>h(g(f(x)))<
 </div>
 
 <a class="pilcrow h4" href="#on">¶</a>
-<h4 id="on"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1552">on</a> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
+<h4 id="on"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1552">on</a> :: (b -> b -> c) -> (a -> b) -> a -> a -> c</code></h4>
 
 <p>Takes a binary function <code>f</code>, a unary function <code>g</code>, and two
 values <code>x</code> and <code>y</code>. Returns <code>f(g(x))(g(y))</code>.</p>
@@ -2008,7 +2009,7 @@ values <code>x</code> and <code>y</code>. Returns <code>f(g(x))(g(y))</code>.</p
 </div>
 
 <a class="pilcrow h4" href="#on_">¶</a>
-<h4 id="on_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1570">on_</a> <span class="tight">:</span><span class="tight">:</span> ((b, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
+<h4 id="on_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1570">on_</a> :: ((b, b) -> c) -> (a -> b) -> a -> a -> c</code></h4>
 
 <p>Variant of <a href="#on"><code>on</code></a> which takes an uncurried binary function.</p>
 <a class="pilcrow h3" href="#maybe-type">¶</a>
@@ -2018,15 +2019,15 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 <p>The Maybe type satisfies the <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#setoid">Setoid</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#monoid">Monoid</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#monad">Monad</a>,
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#alternative">Alternative</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#traversable">Traversable</a>, and <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#extend">Extend</a> specifications.</p>
 <a class="pilcrow h4" href="#MaybeType">¶</a>
-<h4 id="MaybeType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1586">MaybeType</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a></code></h4>
+<h4 id="MaybeType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1586">MaybeType</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a></code></h4>
 
 <p>A <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#UnaryType"><code>UnaryType</code></a> for use with <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1">sanctuary-def</a>.</p>
 <a class="pilcrow h4" href="#Maybe">¶</a>
-<h4 id="Maybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1591">Maybe</a> <span class="tight">:</span><span class="tight">:</span> <a href="#type-representatives">TypeRep</a> <a href="#MaybeType">Maybe</a></code></h4>
+<h4 id="Maybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1591">Maybe</a> :: <a href="#type-representatives">TypeRep</a> <a href="#MaybeType">Maybe</a></code></h4>
 
 <p>The <a href="#type-representatives">type representative</a> for the Maybe type.</p>
 <a class="pilcrow h4" href="#Nothing">¶</a>
-<h4 id="Nothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1618">Nothing</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="Nothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1618">Nothing</a> :: <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Nothing.</p>
 <div class="examples">
@@ -2037,7 +2038,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Just">¶</a>
-<h4 id="Just"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1628">Just</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="Just"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1628">Just</a> :: a -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a value of any type and returns a Just with the given value.</p>
 <div class="examples">
@@ -2048,11 +2049,11 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.@@type">¶</a>
-<h4 id="Maybe.@@type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1641">Maybe.@@type</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="Maybe.@@type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1641">Maybe.@@type</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Maybe type identifier, <code>&#39;sanctuary/Maybe&#39;</code>.</p>
 <a class="pilcrow h4" href="#Maybe.fantasy-land/empty">¶</a>
-<h4 id="Maybe.fantasy-land/empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1646">Maybe.fantasy-land/empty</a> <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="Maybe.fantasy-land/empty"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1646">Maybe.fantasy-land/empty</a> :: () -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Returns Nothing.</p>
 <div class="examples">
@@ -2063,7 +2064,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.fantasy-land/of">¶</a>
-<h4 id="Maybe.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1656">Maybe.fantasy-land/of</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="Maybe.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1656">Maybe.fantasy-land/of</a> :: a -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a value of any type and returns a Just with the given value.</p>
 <div class="examples">
@@ -2074,7 +2075,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.fantasy-land/zero">¶</a>
-<h4 id="Maybe.fantasy-land/zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1666">Maybe.fantasy-land/zero</a> <span class="tight">:</span><span class="tight">:</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="Maybe.fantasy-land/zero"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1666">Maybe.fantasy-land/zero</a> :: () -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Returns Nothing.</p>
 <div class="examples">
@@ -2085,7 +2086,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.isNothing">¶</a>
-<h4 id="Maybe.prototype.isNothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1676">Maybe#isNothing</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="Maybe.prototype.isNothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1676">Maybe#isNothing</a> :: <a href="#MaybeType">Maybe</a> a ~> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p><code>true</code> if <code>this</code> is Nothing; <code>false</code> if <code>this</code> is a Just.</p>
 <div class="examples">
@@ -2100,7 +2101,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.isJust">¶</a>
-<h4 id="Maybe.prototype.isJust"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1688">Maybe#isJust</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="Maybe.prototype.isJust"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1688">Maybe#isJust</a> :: <a href="#MaybeType">Maybe</a> a ~> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p><code>true</code> if <code>this</code> is a Just; <code>false</code> if <code>this</code> is Nothing.</p>
 <div class="examples">
@@ -2115,7 +2116,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.toString">¶</a>
-<h4 id="Maybe.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1700">Maybe#toString</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="Maybe.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1700">Maybe#toString</a> :: <a href="#MaybeType">Maybe</a> a ~> () -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Returns the string representation of the Maybe.</p>
 <div class="examples">
@@ -2130,7 +2131,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.inspect">¶</a>
-<h4 id="Maybe.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1715">Maybe#inspect</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="Maybe.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1715">Maybe#inspect</a> :: <a href="#MaybeType">Maybe</a> a ~> () -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Returns the string representation of the Maybe. This method is used by
 <code>util.inspect</code> and the REPL to format a Maybe for display.</p>
@@ -2147,7 +2148,7 @@ either a Just whose value is of type <code>a</code> or Nothing (with no value).<
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/equals">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1731">Maybe#fantasy-land/equals</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a <span class="arrow">=&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1731">Maybe#fantasy-land/equals</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a => <a href="#MaybeType">Maybe</a> a ~> <a href="#MaybeType">Maybe</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Takes a value <code>m</code> of the same type and returns <code>true</code> if:</p>
 <ul>
@@ -2177,7 +2178,7 @@ to <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#e
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/lte">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1758">Maybe#fantasy-land/lte</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a <span class="arrow">=&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="Maybe.prototype.fantasy-land/lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1758">Maybe#fantasy-land/lte</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a => <a href="#MaybeType">Maybe</a> a ~> <a href="#MaybeType">Maybe</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Takes a value <code>m</code> of the same type and returns <code>true</code> if:</p>
 <ul>
@@ -2211,7 +2212,7 @@ or equal to the value of <code>m</code> according to <a href="https://github.com
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/concat">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1787">Maybe#fantasy-land/concat</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> a <span class="arrow">=&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="Maybe.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1787">Maybe#fantasy-land/concat</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> a => <a href="#MaybeType">Maybe</a> a ~> <a href="#MaybeType">Maybe</a> a -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Returns the result of concatenating two Maybe values of the same type.
 <code>a</code> must have a <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#semigroup">Semigroup</a>.</p>
@@ -2241,7 +2242,7 @@ the given Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/map">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1820">Maybe#fantasy-land/map</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
+<h4 id="Maybe.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1820">Maybe#fantasy-land/map</a> :: <a href="#MaybeType">Maybe</a> a ~> (a -> b) -> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is Nothing; otherwise
 it returns a Just whose value is the result of applying the function
@@ -2258,7 +2259,7 @@ to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/ap">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1837">Maybe#fantasy-land/ap</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="#MaybeType">Maybe</a> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
+<h4 id="Maybe.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1837">Maybe#fantasy-land/ap</a> :: <a href="#MaybeType">Maybe</a> a ~> <a href="#MaybeType">Maybe</a> (a -> b) -> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a Maybe and returns Nothing unless <code>this</code> is a Just <em>and</em> the
 argument is a Just, in which case it returns a Just whose value is
@@ -2283,7 +2284,7 @@ the result of applying the given Just&#39;s value to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/chain">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1860">Maybe#fantasy-land/chain</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
+<h4 id="Maybe.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1860">Maybe#fantasy-land/chain</a> :: <a href="#MaybeType">Maybe</a> a ~> (a -> <a href="#MaybeType">Maybe</a> b) -> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is Nothing; otherwise
 it returns the result of applying the function to this Just&#39;s value.</p>
@@ -2303,7 +2304,7 @@ it returns the result of applying the function to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/alt">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1879">Maybe#fantasy-land/alt</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="Maybe.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1879">Maybe#fantasy-land/alt</a> :: <a href="#MaybeType">Maybe</a> a ~> <a href="#MaybeType">Maybe</a> a -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Chooses between <code>this</code> and the other Maybe provided as an argument.
 Returns <code>this</code> if <code>this</code> is a Just; the other Maybe otherwise.</p>
@@ -2327,7 +2328,7 @@ Returns <code>this</code> if <code>this</code> is a Just; the other Maybe otherw
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/reduce">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1901">Maybe#fantasy-land/reduce</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> ((b, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="Maybe.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1901">Maybe#fantasy-land/reduce</a> :: <a href="#MaybeType">Maybe</a> a ~> ((b, a) -> b, b) -> b</code></h4>
 
 <p>Takes a function and an initial value of any type, and returns:</p>
 <ul>
@@ -2349,7 +2350,7 @@ Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/traverse">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1921">Maybe#fantasy-land/traverse</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f <span class="arrow">=&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> (<a href="#type-representatives">TypeRep</a> f, a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (<a href="#MaybeType">Maybe</a> b)</code></h4>
+<h4 id="Maybe.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1921">Maybe#fantasy-land/traverse</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f => <a href="#MaybeType">Maybe</a> a ~> (<a href="#type-representatives">TypeRep</a> f, a -> f b) -> f (<a href="#MaybeType">Maybe</a> b)</code></h4>
 
 <p>Takes the type representative of some <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#applicative">Applicative</a> and a function
 which returns a value of that Applicative, and returns:</p>
@@ -2373,7 +2374,7 @@ first function to this Just&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Maybe.prototype.fantasy-land/extend">¶</a>
-<h4 id="Maybe.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1943">Maybe#fantasy-land/extend</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow">~&gt;</span> (<a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
+<h4 id="Maybe.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1943">Maybe#fantasy-land/extend</a> :: <a href="#MaybeType">Maybe</a> a ~> (<a href="#MaybeType">Maybe</a> a -> b) -> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is Nothing; otherwise
 it returns a Just whose value is the result of applying the function
@@ -2390,7 +2391,7 @@ to <code>this</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#isNothing">¶</a>
-<h4 id="isNothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1960">isNothing</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="isNothing"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1960">isNothing</a> :: <a href="#MaybeType">Maybe</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Maybe is Nothing; <code>false</code> if it is a Just.</p>
 <div class="examples">
@@ -2405,7 +2406,7 @@ to <code>this</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#isJust">¶</a>
-<h4 id="isJust"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1976">isJust</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="isJust"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1976">isJust</a> :: <a href="#MaybeType">Maybe</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Maybe is a Just; <code>false</code> if it is Nothing.</p>
 <div class="examples">
@@ -2420,7 +2421,7 @@ to <code>this</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#fromMaybe">¶</a>
-<h4 id="fromMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1992">fromMaybe</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="fromMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L1992">fromMaybe</a> :: a -> <a href="#MaybeType">Maybe</a> a -> a</code></h4>
 
 <p>Takes a default value and a Maybe, and returns the Maybe&#39;s value
 if the Maybe is a Just; the default value otherwise.</p>
@@ -2438,7 +2439,7 @@ if the Maybe is a Just; the default value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#fromMaybe_">¶</a>
-<h4 id="fromMaybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2012">fromMaybe_</a> <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="fromMaybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2012">fromMaybe_</a> :: (() -> a) -> <a href="#MaybeType">Maybe</a> a -> a</code></h4>
 
 <p>Variant of <a href="#fromMaybe"><code>fromMaybe</code></a> which takes a thunk so the default
 value is only computed if required.</p>
@@ -2458,7 +2459,7 @@ value is only computed if required.</p>
 </div>
 
 <a class="pilcrow h4" href="#maybeToNullable">¶</a>
-<h4 id="maybeToNullable"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2031">maybeToNullable</a> <span class="tight">:</span><span class="tight">:</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Nullable">Nullable</a> a</code></h4>
+<h4 id="maybeToNullable"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2031">maybeToNullable</a> :: <a href="#MaybeType">Maybe</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Nullable">Nullable</a> a</code></h4>
 
 <p>Returns the given Maybe&#39;s value if the Maybe is a Just; <code>null</code> otherwise.
 <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Nullable">Nullable</a> is defined in <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1">sanctuary-def</a>.</p>
@@ -2475,7 +2476,7 @@ value is only computed if required.</p>
 </div>
 
 <a class="pilcrow h4" href="#toMaybe">¶</a>
-<h4 id="toMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2051">toMaybe</a> <span class="tight">:</span><span class="tight">:</span> a? <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="toMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2051">toMaybe</a> :: a? -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a value and returns Nothing if the value is <code>null</code> or <code>undefined</code>;
 Just the value otherwise.</p>
@@ -2491,7 +2492,7 @@ Just the value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#maybe">¶</a>
-<h4 id="maybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2068">maybe</a> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="maybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2068">maybe</a> :: b -> (a -> b) -> <a href="#MaybeType">Maybe</a> a -> b</code></h4>
 
 <p>Takes a value of any type, a function, and a Maybe. If the Maybe is
 a Just, the return value is the result of applying the function to
@@ -2509,7 +2510,7 @@ the Just&#39;s value. Otherwise, the first argument is returned.</p>
 </div>
 
 <a class="pilcrow h4" href="#maybe_">¶</a>
-<h4 id="maybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2088">maybe_</a> <span class="tight">:</span><span class="tight">:</span> (() <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="maybe_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2088">maybe_</a> :: (() -> b) -> (a -> b) -> <a href="#MaybeType">Maybe</a> a -> b</code></h4>
 
 <p>Variant of <a href="#maybe"><code>maybe</code></a> which takes a thunk so the default value
 is only computed if required.</p>
@@ -2529,7 +2530,7 @@ is only computed if required.</p>
 </div>
 
 <a class="pilcrow h4" href="#justs">¶</a>
-<h4 id="justs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2107">justs</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="#MaybeType">Maybe</a> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a</code></h4>
+<h4 id="justs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2107">justs</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="#MaybeType">Maybe</a> a) -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a</code></h4>
 
 <p>Takes an array of Maybes and returns an array containing each Just&#39;s
 value. Equivalent to Haskell&#39;s <code>catMaybes</code> function.</p>
@@ -2542,7 +2543,7 @@ value. Equivalent to Haskell&#39;s <code>catMaybes</code> function.</p>
 </div>
 
 <a class="pilcrow h4" href="#mapMaybe">¶</a>
-<h4 id="mapMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2126">mapMaybe</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> b</code></h4>
+<h4 id="mapMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2126">mapMaybe</a> :: (a -> <a href="#MaybeType">Maybe</a> b) -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> b</code></h4>
 
 <p>Takes a function and an array, applies the function to each element of
 the array, and returns an array of &quot;successful&quot; results. If the result of
@@ -2558,7 +2559,7 @@ the output array.</p>
 </div>
 
 <a class="pilcrow h4" href="#encase">¶</a>
-<h4 id="encase"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2146">encase</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
+<h4 id="encase"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2146">encase</a> :: (a -> b) -> a -> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a unary function <code>f</code> which may throw and a value <code>x</code> of any type,
 and applies <code>f</code> to <code>x</code> inside a <code>try</code> block. If an exception is caught,
@@ -2577,27 +2578,27 @@ result of applying <code>f</code> to <code>x</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#encase2">¶</a>
-<h4 id="encase2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2171">encase2</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> c</code></h4>
+<h4 id="encase2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2171">encase2</a> :: (a -> b -> c) -> a -> b -> <a href="#MaybeType">Maybe</a> c</code></h4>
 
 <p>Binary version of <a href="#encase"><code>encase</code></a>.</p>
 <p>See also <a href="#encase2_"><code>encase2_</code></a>.</p>
 <a class="pilcrow h4" href="#encase2_">¶</a>
-<h4 id="encase2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2181">encase2_</a> <span class="tight">:</span><span class="tight">:</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> c</code></h4>
+<h4 id="encase2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2181">encase2_</a> :: ((a, b) -> c) -> a -> b -> <a href="#MaybeType">Maybe</a> c</code></h4>
 
 <p>Variant of <a href="#encase2"><code>encase2</code></a> which takes an uncurried binary
 function.</p>
 <a class="pilcrow h4" href="#encase3">¶</a>
-<h4 id="encase3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2195">encase3</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> d</code></h4>
+<h4 id="encase3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2195">encase3</a> :: (a -> b -> c -> d) -> a -> b -> c -> <a href="#MaybeType">Maybe</a> d</code></h4>
 
 <p>Ternary version of <a href="#encase"><code>encase</code></a>.</p>
 <p>See also <a href="#encase3_"><code>encase3_</code></a>.</p>
 <a class="pilcrow h4" href="#encase3_">¶</a>
-<h4 id="encase3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2206">encase3_</a> <span class="tight">:</span><span class="tight">:</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> d</code></h4>
+<h4 id="encase3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2206">encase3_</a> :: ((a, b, c) -> d) -> a -> b -> c -> <a href="#MaybeType">Maybe</a> d</code></h4>
 
 <p>Variant of <a href="#encase3"><code>encase3</code></a> which takes an uncurried ternary
 function.</p>
 <a class="pilcrow h4" href="#maybeToEither">¶</a>
-<h4 id="maybeToEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2223">maybeToEither</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
+<h4 id="maybeToEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2223">maybeToEither</a> :: a -> <a href="#MaybeType">Maybe</a> b -> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Converts a Maybe to an Either. Nothing becomes a Left (containing the
 first argument); a Just becomes a Right.</p>
@@ -2621,15 +2622,15 @@ value is of type <code>b</code>.</p>
 <p>The Either type satisfies the <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#setoid">Setoid</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#semigroup">Semigroup</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#monad">Monad</a>,
 <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#alt">Alt</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#traversable">Traversable</a>, <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#extend">Extend</a>, and <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#bifunctor">Bifunctor</a> specifications.</p>
 <a class="pilcrow h4" href="#EitherType">¶</a>
-<h4 id="EitherType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2252">EitherType</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a></code></h4>
+<h4 id="EitherType"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2252">EitherType</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Type">Type</a></code></h4>
 
 <p>A <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#BinaryType"><code>BinaryType</code></a> for use with <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1">sanctuary-def</a>.</p>
 <a class="pilcrow h4" href="#Either">¶</a>
-<h4 id="Either"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2257">Either</a> <span class="tight">:</span><span class="tight">:</span> <a href="#type-representatives">TypeRep</a> <a href="#EitherType">Either</a></code></h4>
+<h4 id="Either"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2257">Either</a> :: <a href="#type-representatives">TypeRep</a> <a href="#EitherType">Either</a></code></h4>
 
 <p>The <a href="#type-representatives">type representative</a> for the Either type.</p>
 <a class="pilcrow h4" href="#Left">¶</a>
-<h4 id="Left"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2285">Left</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
+<h4 id="Left"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2285">Left</a> :: a -> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Takes a value of any type and returns a Left with the given value.</p>
 <div class="examples">
@@ -2640,7 +2641,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Right">¶</a>
-<h4 id="Right"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2298">Right</a> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
+<h4 id="Right"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2298">Right</a> :: b -> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Takes a value of any type and returns a Right with the given value.</p>
 <div class="examples">
@@ -2651,11 +2652,11 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.@@type">¶</a>
-<h4 id="Either.@@type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2311">Either.@@type</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="Either.@@type"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2311">Either.@@type</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Either type identifier, <code>&#39;sanctuary/Either&#39;</code>.</p>
 <a class="pilcrow h4" href="#Either.fantasy-land/of">¶</a>
-<h4 id="Either.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2316">Either.fantasy-land/of</a> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
+<h4 id="Either.fantasy-land/of"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2316">Either.fantasy-land/of</a> :: b -> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Takes a value of any type and returns a Right with the given value.</p>
 <div class="examples">
@@ -2666,7 +2667,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.isLeft">¶</a>
-<h4 id="Either.prototype.isLeft"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2326">Either#isLeft</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="Either.prototype.isLeft"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2326">Either#isLeft</a> :: <a href="#EitherType">Either</a> a b ~> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p><code>true</code> if <code>this</code> is a Left; <code>false</code> if <code>this</code> is a Right.</p>
 <div class="examples">
@@ -2681,7 +2682,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.isRight">¶</a>
-<h4 id="Either.prototype.isRight"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2338">Either#isRight</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="Either.prototype.isRight"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2338">Either#isRight</a> :: <a href="#EitherType">Either</a> a b ~> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p><code>true</code> if <code>this</code> is a Right; <code>false</code> if <code>this</code> is a Left.</p>
 <div class="examples">
@@ -2696,7 +2697,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.toString">¶</a>
-<h4 id="Either.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2350">Either#toString</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="Either.prototype.toString"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2350">Either#toString</a> :: <a href="#EitherType">Either</a> a b ~> () -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Returns the string representation of the Either.</p>
 <div class="examples">
@@ -2711,7 +2712,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.inspect">¶</a>
-<h4 id="Either.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2366">Either#inspect</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> () <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="Either.prototype.inspect"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2366">Either#inspect</a> :: <a href="#EitherType">Either</a> a b ~> () -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Returns the string representation of the Either. This method is used by
 <code>util.inspect</code> and the REPL to format a Either for display.</p>
@@ -2728,7 +2729,7 @@ value is of type <code>b</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/equals">¶</a>
-<h4 id="Either.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2382">Either#fantasy-land/equals</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> b) <span class="arrow">=&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/equals"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2382">Either#fantasy-land/equals</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> b) => <a href="#EitherType">Either</a> a b ~> <a href="#EitherType">Either</a> a b -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Takes a value <code>e</code> of the same type and returns <code>true</code> if:</p>
 <ul>
@@ -2747,7 +2748,7 @@ equal according to <a href="https://github.com/sanctuary-js/sanctuary-type-class
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/lte">¶</a>
-<h4 id="Either.prototype.fantasy-land/lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2400">Either#fantasy-land/lte</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> b) <span class="arrow">=&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="Either.prototype.fantasy-land/lte"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2400">Either#fantasy-land/lte</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> b) => <a href="#EitherType">Either</a> a b ~> <a href="#EitherType">Either</a> a b -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Takes a value <code>e</code> of the same type and returns <code>true</code> if:</p>
 <ul>
@@ -2777,7 +2778,7 @@ is less than or equal to the value of <code>e</code> according to <a href="https
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/concat">¶</a>
-<h4 id="Either.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2428">Either#fantasy-land/concat</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> b) <span class="arrow">=&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
+<h4 id="Either.prototype.fantasy-land/concat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2428">Either#fantasy-land/concat</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> b) => <a href="#EitherType">Either</a> a b ~> <a href="#EitherType">Either</a> a b -> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Returns the result of concatenating two Either values of the same type.
 <code>a</code> must have a <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#semigroup">Semigroup</a>, as must <code>b</code>.</p>
@@ -2808,7 +2809,7 @@ the given Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/map">¶</a>
-<h4 id="Either.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2462">Either#fantasy-land/map</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a c</code></h4>
+<h4 id="Either.prototype.fantasy-land/map"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2462">Either#fantasy-land/map</a> :: <a href="#EitherType">Either</a> a b ~> (b -> c) -> <a href="#EitherType">Either</a> a c</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is a Left; otherwise it
 returns a Right whose value is the result of applying the function to
@@ -2826,7 +2827,7 @@ this Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/bimap">¶</a>
-<h4 id="Either.prototype.fantasy-land/bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2481">Either#fantasy-land/bimap</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c, b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> d) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> c d</code></h4>
+<h4 id="Either.prototype.fantasy-land/bimap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2481">Either#fantasy-land/bimap</a> :: <a href="#EitherType">Either</a> a b ~> (a -> c, b -> d) -> <a href="#EitherType">Either</a> c d</code></h4>
 
 <p>Takes two functions and returns:</p>
 <ul>
@@ -2851,7 +2852,7 @@ left side as well as the right side.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/ap">¶</a>
-<h4 id="Either.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2505">Either#fantasy-land/ap</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="#EitherType">Either</a> a (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a c</code></h4>
+<h4 id="Either.prototype.fantasy-land/ap"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2505">Either#fantasy-land/ap</a> :: <a href="#EitherType">Either</a> a b ~> <a href="#EitherType">Either</a> a (b -> c) -> <a href="#EitherType">Either</a> a c</code></h4>
 
 <p>Takes an Either and returns a Left unless <code>this</code> is a Right <em>and</em> the
 argument is a Right, in which case it returns a Right whose value is
@@ -2876,7 +2877,7 @@ the result of applying the given Right&#39;s value to this Right&#39;s value.</p
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/chain">¶</a>
-<h4 id="Either.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2528">Either#fantasy-land/chain</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a c</code></h4>
+<h4 id="Either.prototype.fantasy-land/chain"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2528">Either#fantasy-land/chain</a> :: <a href="#EitherType">Either</a> a b ~> (b -> <a href="#EitherType">Either</a> a c) -> <a href="#EitherType">Either</a> a c</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is a Left; otherwise
 it returns the result of applying the function to this Right&#39;s value.</p>
@@ -2900,7 +2901,7 @@ it returns the result of applying the function to this Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/alt">¶</a>
-<h4 id="Either.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2552">Either#fantasy-land/alt</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
+<h4 id="Either.prototype.fantasy-land/alt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2552">Either#fantasy-land/alt</a> :: <a href="#EitherType">Either</a> a b ~> <a href="#EitherType">Either</a> a b -> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Chooses between <code>this</code> and the other Either provided as an argument.
 Returns <code>this</code> if <code>this</code> is a Right; the other Either otherwise.</p>
@@ -2924,7 +2925,7 @@ Returns <code>this</code> if <code>this</code> is a Right; the other Either othe
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/reduce">¶</a>
-<h4 id="Either.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2574">Either#fantasy-land/reduce</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> ((c, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
+<h4 id="Either.prototype.fantasy-land/reduce"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2574">Either#fantasy-land/reduce</a> :: <a href="#EitherType">Either</a> a b ~> ((c, b) -> c, c) -> c</code></h4>
 
 <p>Takes a function and an initial value of any type, and returns:</p>
 <ul>
@@ -2946,7 +2947,7 @@ Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/traverse">¶</a>
-<h4 id="Either.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2594">Either#fantasy-land/traverse</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f <span class="arrow">=&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> (<a href="#type-representatives">TypeRep</a> f, b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f (<a href="#EitherType">Either</a> a c)</code></h4>
+<h4 id="Either.prototype.fantasy-land/traverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2594">Either#fantasy-land/traverse</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f => <a href="#EitherType">Either</a> a b ~> (<a href="#type-representatives">TypeRep</a> f, b -> f c) -> f (<a href="#EitherType">Either</a> a c)</code></h4>
 
 <p>Takes the type representative of some <a href="https://github.com/fantasyland/fantasy-land/tree/v3.3.0#applicative">Applicative</a> and a function
 which returns a value of that Applicative, and returns:</p>
@@ -2970,7 +2971,7 @@ the first function to this Right&#39;s value.</p>
 </div>
 
 <a class="pilcrow h4" href="#Either.prototype.fantasy-land/extend">¶</a>
-<h4 id="Either.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2616">Either#fantasy-land/extend</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow">~&gt;</span> (<a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a c</code></h4>
+<h4 id="Either.prototype.fantasy-land/extend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2616">Either#fantasy-land/extend</a> :: <a href="#EitherType">Either</a> a b ~> (<a href="#EitherType">Either</a> a b -> c) -> <a href="#EitherType">Either</a> a c</code></h4>
 
 <p>Takes a function and returns <code>this</code> if <code>this</code> is a Left; otherwise it
 returns a Right whose value is the result of applying the function to
@@ -2987,7 +2988,7 @@ returns a Right whose value is the result of applying the function to
 </div>
 
 <a class="pilcrow h4" href="#isLeft">¶</a>
-<h4 id="isLeft"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2633">isLeft</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="isLeft"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2633">isLeft</a> :: <a href="#EitherType">Either</a> a b -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Either is a Left; <code>false</code> if it is a Right.</p>
 <div class="examples">
@@ -3002,7 +3003,7 @@ returns a Right whose value is the result of applying the function to
 </div>
 
 <a class="pilcrow h4" href="#isRight">¶</a>
-<h4 id="isRight"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2649">isRight</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="isRight"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2649">isRight</a> :: <a href="#EitherType">Either</a> a b -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given Either is a Right; <code>false</code> if it is a Left.</p>
 <div class="examples">
@@ -3017,7 +3018,7 @@ returns a Right whose value is the result of applying the function to
 </div>
 
 <a class="pilcrow h4" href="#fromEither">¶</a>
-<h4 id="fromEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2665">fromEither</a> <span class="tight">:</span><span class="tight">:</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="fromEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2665">fromEither</a> :: b -> <a href="#EitherType">Either</a> a b -> b</code></h4>
 
 <p>Takes a default value and an Either, and returns the Right value
 if the Either is a Right; the default value otherwise.</p>
@@ -3033,7 +3034,7 @@ if the Either is a Right; the default value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#toEither">¶</a>
-<h4 id="toEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2682">toEither</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b? <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b</code></h4>
+<h4 id="toEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2682">toEither</a> :: a -> b? -> <a href="#EitherType">Either</a> a b</code></h4>
 
 <p>Converts an arbitrary value to an Either: a Left if the value is <code>null</code>
 or <code>undefined</code>; a Right otherwise. The first argument specifies the
@@ -3058,7 +3059,7 @@ value of the Left in the &quot;failure&quot; case.</p>
 </div>
 
 <a class="pilcrow h4" href="#either">¶</a>
-<h4 id="either"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2706">either</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c</code></h4>
+<h4 id="either"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2706">either</a> :: (a -> c) -> (b -> c) -> <a href="#EitherType">Either</a> a b -> c</code></h4>
 
 <p>Takes two functions and an Either, and returns the result of
 applying the first function to the Left&#39;s value, if the Either
@@ -3076,7 +3077,7 @@ Right&#39;s value, if the Either is a Right.</p>
 </div>
 
 <a class="pilcrow h4" href="#lefts">¶</a>
-<h4 id="lefts"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2725">lefts</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="#EitherType">Either</a> a b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a</code></h4>
+<h4 id="lefts"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2725">lefts</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="#EitherType">Either</a> a b) -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a</code></h4>
 
 <p>Takes an array of Eithers and returns an array containing each Left&#39;s
 value.</p>
@@ -3089,7 +3090,7 @@ value.</p>
 </div>
 
 <a class="pilcrow h4" href="#rights">¶</a>
-<h4 id="rights"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2744">rights</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="#EitherType">Either</a> a b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> b</code></h4>
+<h4 id="rights"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2744">rights</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="#EitherType">Either</a> a b) -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> b</code></h4>
 
 <p>Takes an array of Eithers and returns an array containing each Right&#39;s
 value.</p>
@@ -3102,7 +3103,7 @@ value.</p>
 </div>
 
 <a class="pilcrow h4" href="#tagBy">¶</a>
-<h4 id="tagBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2763">tagBy</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> a a</code></h4>
+<h4 id="tagBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2763">tagBy</a> :: (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> a -> <a href="#EitherType">Either</a> a a</code></h4>
 
 <p>Takes a predicate and a value, and returns a Right of the value if it
 satisfies the predicate; a Left of the value otherwise.</p>
@@ -3118,7 +3119,7 @@ satisfies the predicate; a Left of the value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#encaseEither">¶</a>
-<h4 id="encaseEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2780">encaseEither</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Error">Error</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> l r</code></h4>
+<h4 id="encaseEither"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2780">encaseEither</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Error">Error</a> -> l) -> (a -> r) -> a -> <a href="#EitherType">Either</a> l r</code></h4>
 
 <p>Takes two unary functions, <code>f</code> and <code>g</code>, the second of which may throw,
 and a value <code>x</code> of any type. Applies <code>g</code> to <code>x</code> inside a <code>try</code> block.
@@ -3142,27 +3143,27 @@ value is a Right containing the result of applying <code>g</code> to <code>x</co
 </div>
 
 <a class="pilcrow h4" href="#encaseEither2">¶</a>
-<h4 id="encaseEither2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2813">encaseEither2</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Error">Error</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> l r</code></h4>
+<h4 id="encaseEither2"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2813">encaseEither2</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Error">Error</a> -> l) -> (a -> b -> r) -> a -> b -> <a href="#EitherType">Either</a> l r</code></h4>
 
 <p>Binary version of <a href="#encaseEither"><code>encaseEither</code></a>.</p>
 <p>See also <a href="#encaseEither2_"><code>encaseEither2_</code></a>.</p>
 <a class="pilcrow h4" href="#encaseEither2_">¶</a>
-<h4 id="encaseEither2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2827">encaseEither2_</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Error">Error</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> ((a, b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> l r</code></h4>
+<h4 id="encaseEither2_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2827">encaseEither2_</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Error">Error</a> -> l) -> ((a, b) -> r) -> a -> b -> <a href="#EitherType">Either</a> l r</code></h4>
 
 <p>Variant of <a href="#encaseEither2"><code>encaseEither2</code></a> which takes an uncurried
 binary function.</p>
 <a class="pilcrow h4" href="#encaseEither3">¶</a>
-<h4 id="encaseEither3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2844">encaseEither3</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Error">Error</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> l r</code></h4>
+<h4 id="encaseEither3"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2844">encaseEither3</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Error">Error</a> -> l) -> (a -> b -> c -> r) -> a -> b -> c -> <a href="#EitherType">Either</a> l r</code></h4>
 
 <p>Ternary version of <a href="#encaseEither"><code>encaseEither</code></a>.</p>
 <p>See also <a href="#encaseEither3_"><code>encaseEither3_</code></a>.</p>
 <a class="pilcrow h4" href="#encaseEither3_">¶</a>
-<h4 id="encaseEither3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2858">encaseEither3_</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Error">Error</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> l) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> ((a, b, c) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> r) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> c <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#EitherType">Either</a> l r</code></h4>
+<h4 id="encaseEither3_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2858">encaseEither3_</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Error">Error</a> -> l) -> ((a, b, c) -> r) -> a -> b -> c -> <a href="#EitherType">Either</a> l r</code></h4>
 
 <p>Variant of <a href="#encaseEither3"><code>encaseEither3</code></a> which takes an uncurried
 ternary function.</p>
 <a class="pilcrow h4" href="#eitherToMaybe">¶</a>
-<h4 id="eitherToMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2875">eitherToMaybe</a> <span class="tight">:</span><span class="tight">:</span> <a href="#EitherType">Either</a> a b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
+<h4 id="eitherToMaybe"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2875">eitherToMaybe</a> :: <a href="#EitherType">Either</a> a b -> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Converts an Either to a Maybe. A Left becomes Nothing; a Right becomes
 a Just.</p>
@@ -3181,7 +3182,7 @@ a Just.</p>
 <a class="pilcrow h3" href="#logic">¶</a>
 <h3 id="logic">Logic</h3>
 <a class="pilcrow h4" href="#and">¶</a>
-<h4 id="and"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2897">and</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="and"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2897">and</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Boolean &quot;and&quot;.</p>
 <div class="examples">
@@ -3204,7 +3205,7 @@ a Just.</p>
 </div>
 
 <a class="pilcrow h4" href="#or">¶</a>
-<h4 id="or"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2919">or</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="or"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2919">or</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Boolean &quot;or&quot;.</p>
 <div class="examples">
@@ -3227,7 +3228,7 @@ a Just.</p>
 </div>
 
 <a class="pilcrow h4" href="#not">¶</a>
-<h4 id="not"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2941">not</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="not"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2941">not</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Boolean &quot;not&quot;.</p>
 <p>See also <a href="#complement"><code>complement</code></a>.</p>
@@ -3243,7 +3244,7 @@ a Just.</p>
 </div>
 
 <a class="pilcrow h4" href="#complement">¶</a>
-<h4 id="complement"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2959">complement</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="complement"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2959">complement</a> :: (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Takes a unary predicate and a value of any type, and returns the logical
 negation of applying the predicate to the value.</p>
@@ -3260,7 +3261,7 @@ negation of applying the predicate to the value.</p>
 </div>
 
 <a class="pilcrow h4" href="#ifElse">¶</a>
-<h4 id="ifElse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2978">ifElse</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="ifElse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L2978">ifElse</a> :: (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> (a -> b) -> (a -> b) -> a -> b</code></h4>
 
 <p>Takes a unary predicate, a unary &quot;if&quot; function, a unary &quot;else&quot;
 function, and a value of any type, and returns the result of
@@ -3280,7 +3281,7 @@ value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#when">¶</a>
-<h4 id="when"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3000">when</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="when"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3000">when</a> :: (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> (a -> a) -> a -> a</code></h4>
 
 <p>Takes a unary predicate, a unary function, and a value of any type, and
 returns the result of applying the function to the value if the value
@@ -3298,7 +3299,7 @@ satisfies the predicate; the value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#unless">¶</a>
-<h4 id="unless"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3020">unless</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a</code></h4>
+<h4 id="unless"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3020">unless</a> :: (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> (a -> a) -> a -> a</code></h4>
 
 <p>Takes a unary predicate, a unary function, and a value of any type, and
 returns the result of applying the function to the value if the value
@@ -3316,7 +3317,7 @@ does not satisfy the predicate; the value otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#allPass">¶</a>
-<h4 id="allPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3040">allPass</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="allPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3040">allPass</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Takes an array of unary predicates and a value of any type
 and returns <code>true</code> if all the predicates pass; <code>false</code> otherwise.
@@ -3334,7 +3335,7 @@ first failed predicate.</p>
 </div>
 
 <a class="pilcrow h4" href="#anyPass">¶</a>
-<h4 id="anyPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3059">anyPass</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="anyPass"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3059">anyPass</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Takes an array of unary predicates and a value of any type
 and returns <code>true</code> if any of the predicates pass; <code>false</code> otherwise.
@@ -3365,7 +3366,7 @@ containing <code>&#39;a&#39;</code>, <code>&#39;b&#39;</code>, and <code>&#39;c&
 affects the interpretation of type signatures. Consider the type of
 <a href="#indexOf"><code>indexOf</code></a>:</p>
 <pre><code>a -&gt; List a -&gt; Maybe Integer
-</code></pre><p>Assume the second argument is <code>&#39;hello&#39; <span class="tight">:</span><span class="tight">:</span> List String</code>. <code>a</code> must then be
+</code></pre><p>Assume the second argument is <code>&#39;hello&#39; :: List String</code>. <code>a</code> must then be
 replaced with <code>String</code>:</p>
 <pre><code>String -&gt; List String -&gt; Maybe Integer
 </code></pre><p>Since <code>List String</code> and <code>String</code> are interchangeable, the former can be
@@ -3374,7 +3375,7 @@ replaced with the latter:</p>
 </code></pre><p>It&#39;s then apparent that the first argument needn&#39;t be a single-character
 string; the correspondence between arrays and strings does not hold.</p>
 <a class="pilcrow h4" href="#slice">¶</a>
-<h4 id="slice"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3110">slice</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
+<h4 id="slice"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3110">slice</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Returns Just a list containing the elements from the supplied list
 from a beginning index (inclusive) to an end index (exclusive).
@@ -3406,7 +3407,7 @@ the list.</p>
 </div>
 
 <a class="pilcrow h4" href="#at">¶</a>
-<h4 id="at"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3147">at</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="at"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3147">at</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes an index and a list and returns Just the element of the list at
 the index if the index is within the list&#39;s bounds; Nothing otherwise.
@@ -3427,7 +3428,7 @@ A negative index represents an offset from the length of the list.</p>
 </div>
 
 <a class="pilcrow h4" href="#head">¶</a>
-<h4 id="head"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3168">head</a> <span class="tight">:</span><span class="tight">:</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="head"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3168">head</a> :: <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a list and returns Just the first element of the list if the
 list contains at least one element; Nothing if the list is empty.</p>
@@ -3443,7 +3444,7 @@ list contains at least one element; Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#last">¶</a>
-<h4 id="last"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3185">last</a> <span class="tight">:</span><span class="tight">:</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="last"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3185">last</a> :: <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a list and returns Just the last element of the list if the
 list contains at least one element; Nothing if the list is empty.</p>
@@ -3459,7 +3460,7 @@ list contains at least one element; Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#tail">¶</a>
-<h4 id="tail"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3202">tail</a> <span class="tight">:</span><span class="tight">:</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
+<h4 id="tail"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3202">tail</a> :: <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Takes a list and returns Just a list containing all but the first
 of the list&#39;s elements if the list contains at least one element;
@@ -3476,7 +3477,7 @@ Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#init">¶</a>
-<h4 id="init"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3220">init</a> <span class="tight">:</span><span class="tight">:</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
+<h4 id="init"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3220">init</a> :: <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Takes a list and returns Just a list containing all but the last
 of the list&#39;s elements if the list contains at least one element;
@@ -3493,7 +3494,7 @@ Nothing if the list is empty.</p>
 </div>
 
 <a class="pilcrow h4" href="#take">¶</a>
-<h4 id="take"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3238">take</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
+<h4 id="take"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3238">take</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Returns Just the first N elements of the given collection if N is
 greater than or equal to zero and less than or equal to the length
@@ -3514,7 +3515,7 @@ of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#takeLast">¶</a>
-<h4 id="takeLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3259">takeLast</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
+<h4 id="takeLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3259">takeLast</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Returns Just the last N elements of the given collection if N is
 greater than or equal to zero and less than or equal to the length
@@ -3535,7 +3536,7 @@ of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#drop">¶</a>
-<h4 id="drop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3281">drop</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
+<h4 id="drop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3281">drop</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Returns Just all but the first N elements of the given collection
 if N is greater than or equal to zero and less than or equal to the
@@ -3556,7 +3557,7 @@ length of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#dropLast">¶</a>
-<h4 id="dropLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3302">dropLast</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
+<h4 id="dropLast"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3302">dropLast</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> (<a href="#list">List</a> a)</code></h4>
 
 <p>Returns Just all but the last N elements of the given collection
 if N is greater than or equal to zero and less than or equal to the
@@ -3577,7 +3578,7 @@ length of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#reverse">¶</a>
-<h4 id="reverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3324">reverse</a> <span class="tight">:</span><span class="tight">:</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a</code></h4>
+<h4 id="reverse"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3324">reverse</a> :: <a href="#list">List</a> a -> <a href="#list">List</a> a</code></h4>
 
 <p>Returns the elements of the given list in reverse order.</p>
 <div class="examples">
@@ -3592,7 +3593,7 @@ length of the collection; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#indexOf">¶</a>
-<h4 id="indexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3341">indexOf</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a></code></h4>
+<h4 id="indexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3341">indexOf</a> :: a -> <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a></code></h4>
 
 <p>Takes a value of any type and a list, and returns Just the index
 of the first occurrence of the value in the list, if applicable;
@@ -3617,7 +3618,7 @@ Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#lastIndexOf">¶</a>
-<h4 id="lastIndexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3366">lastIndexOf</a> <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#list">List</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a></code></h4>
+<h4 id="lastIndexOf"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3366">lastIndexOf</a> :: a -> <a href="#list">List</a> a -> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a></code></h4>
 
 <p>Takes a value of any type and a list, and returns Just the index
 of the last occurrence of the value in the list, if applicable;
@@ -3644,7 +3645,7 @@ Nothing otherwise.</p>
 <a class="pilcrow h3" href="#array">¶</a>
 <h3 id="array">Array</h3>
 <a class="pilcrow h4" href="#append">¶</a>
-<h4 id="append"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3394">append</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> (f a)) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
+<h4 id="append"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3394">append</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> (f a)) => a -> f a -> f a</code></h4>
 
 <p>Returns the result of appending the first argument to the second.</p>
 <p>See also <a href="#prepend"><code>prepend</code></a>.</p>
@@ -3664,7 +3665,7 @@ Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#prepend">¶</a>
-<h4 id="prepend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3419">prepend</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> (f a)) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a</code></h4>
+<h4 id="prepend"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3419">prepend</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> f, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Semigroup">Semigroup</a> (f a)) => a -> f a -> f a</code></h4>
 
 <p>Returns the result of prepending the first argument to the second.</p>
 <p>See also <a href="#append"><code>append</code></a>.</p>
@@ -3684,12 +3685,12 @@ Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#joinWith">¶</a>
-<h4 id="joinWith"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3444">joinWith</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="joinWith"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3444">joinWith</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Joins the strings of the second argument separated by the first argument.</p>
 <p>Properties:</p>
 <ul>
-<li><code>forall s <span class="tight">:</span><span class="tight">:</span> String, t <span class="tight">:</span><span class="tight">:</span> String. S.joinWith(s, S.splitOn(s, t)) = t</code></li>
+<li><code>forall s :: String, t :: String. S.joinWith(s, S.splitOn(s, t)) = t</code></li>
 </ul>
 <p>See also <a href="#splitOn"><code>splitOn</code></a>.</p>
 <div class="examples">
@@ -3700,7 +3701,7 @@ Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#elem">¶</a>
-<h4 id="elem"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3464">elem</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f) <span class="arrow">=&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="elem"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3464">elem</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Setoid">Setoid</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f) => a -> f a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Takes a value and a structure and returns <code>true</code> if the value is an
 element of the structure; <code>false</code> otherwise.</p>
@@ -3737,7 +3738,7 @@ element of the structure; <code>false</code> otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#find">¶</a>
-<h4 id="find"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3499">find</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> a</code></h4>
+<h4 id="find"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3499">find</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f => (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> f a -> <a href="#MaybeType">Maybe</a> a</code></h4>
 
 <p>Takes a predicate and a structure and returns Just the leftmost element
 of the structure which satisfies the predicate; Nothing if there is no
@@ -3755,7 +3756,7 @@ such element.</p>
 </div>
 
 <a class="pilcrow h4" href="#pluck">¶</a>
-<h4 id="pluck"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3523">pluck</a> <span class="tight">:</span><span class="tight">:</span> (<a href="#accessible-pseudotype">Accessible</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Functor">Functor</a> f) <span class="arrow">=&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> f b</code></h4>
+<h4 id="pluck"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3523">pluck</a> :: (<a href="#accessible-pseudotype">Accessible</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Functor">Functor</a> f) => <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> f a -> f b</code></h4>
 
 <p>Combines <a href="#map"><code>map</code></a> and <a href="#prop"><code>prop</code></a>. <code>pluck(k, xs)</code> is equivalent
 to <code>map(prop(k), xs)</code>.</p>
@@ -3771,7 +3772,7 @@ to <code>map(prop(k), xs)</code>.</p>
 </div>
 
 <a class="pilcrow h4" href="#unfoldr">¶</a>
-<h4 id="unfoldr"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3548">unfoldr</a> <span class="tight">:</span><span class="tight">:</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Pair">Pair</a> a b)) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a</code></h4>
+<h4 id="unfoldr"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3548">unfoldr</a> :: (b -> <a href="#MaybeType">Maybe</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Pair">Pair</a> a b)) -> b -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a</code></h4>
 
 <p>Takes a function and a seed value, and returns an array generated by
 applying the function repeatedly. The array is initially empty. The
@@ -3792,7 +3793,7 @@ the array and the function is applied to the second element.</p>
 </div>
 
 <a class="pilcrow h4" href="#range">¶</a>
-<h4 id="range"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3572">range</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a></code></h4>
+<h4 id="range"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3572">range</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a></code></h4>
 
 <p>Returns an array of consecutive integers starting with the first argument
 and ending with the second argument minus one. Returns <code>[]</code> if the second
@@ -3813,7 +3814,7 @@ argument is less than or equal to the first argument.</p>
 </div>
 
 <a class="pilcrow h4" href="#groupBy">¶</a>
-<h4 id="groupBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3596">groupBy</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a)</code></h4>
+<h4 id="groupBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3596">groupBy</a> :: (a -> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a)</code></h4>
 
 <p>Splits its array argument into an array of arrays of equal,
 adjacent elements. Equality is determined by the function
@@ -3823,7 +3824,7 @@ for functions that aren&#39;t reflexive, transitive, and symmetric
 <p>See also <a href="#groupBy_"><code>groupBy_</code></a>.</p>
 <p>Properties:</p>
 <ul>
-<li><code>forall f <span class="tight">:</span><span class="tight">:</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>&gt;</span> Boolean, xs <span class="tight">:</span><span class="tight">:</span> Array a.
+<li><code>forall f :: a -&gt; a -&gt; Boolean, xs :: Array a.
  S.join(S.groupBy(f, xs)) = xs</code></li>
 </ul>
 <div class="examples">
@@ -3838,11 +3839,11 @@ for functions that aren&#39;t reflexive, transitive, and symmetric
 </div>
 
 <a class="pilcrow h4" href="#groupBy_">¶</a>
-<h4 id="groupBy_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3627">groupBy_</a> <span class="tight">:</span><span class="tight">:</span> ((a, a) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a)</code></h4>
+<h4 id="groupBy_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3627">groupBy_</a> :: ((a, a) -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a)</code></h4>
 
 <p>Variant of <a href="#groupBy"><code>groupBy</code></a> which takes an uncurried function.</p>
 <a class="pilcrow h4" href="#sort">¶</a>
-<h4 id="sort"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3647">sort</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> (m a)) <span class="arrow">=&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></h4>
+<h4 id="sort"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3647">sort</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> a, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> (m a)) => m a -> m a</code></h4>
 
 <p>Performs a <a href="https://en.wikipedia.org/wiki/Sorting_algorithm#Stability">stable sort</a> of the elements of the given structure, using
 <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a> for comparisons.</p>
@@ -3863,7 +3864,7 @@ for functions that aren&#39;t reflexive, transitive, and symmetric
 </div>
 
 <a class="pilcrow h4" href="#sortBy">¶</a>
-<h4 id="sortBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3674">sortBy</a> <span class="tight">:</span><span class="tight">:</span> (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> b, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> (m a)) <span class="arrow">=&gt;</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> m a</code></h4>
+<h4 id="sortBy"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3674">sortBy</a> :: (<a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Ord">Ord</a> b, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Applicative">Applicative</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> m, <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Monoid">Monoid</a> (m a)) => (a -> b) -> m a -> m a</code></h4>
 
 <p>Performs a <a href="https://en.wikipedia.org/wiki/Sorting_algorithm#Stability">stable sort</a> of the elements of the given structure, using
 <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#lte"><code>Z.lte</code></a> to compare the values produced by applying the given function
@@ -3887,7 +3888,7 @@ to each element of the structure.</p>
 <a class="pilcrow h3" href="#object">¶</a>
 <h3 id="object">Object</h3>
 <a class="pilcrow h4" href="#prop">¶</a>
-<h4 id="prop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3737">prop</a> <span class="tight">:</span><span class="tight">:</span> <a href="#accessible-pseudotype">Accessible</a> a <span class="arrow">=&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="prop"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3737">prop</a> :: <a href="#accessible-pseudotype">Accessible</a> a => <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> a -> b</code></h4>
 
 <p>Takes a property name and an object with known properties and returns
 the value of the specified property. If for some reason the object
@@ -3902,7 +3903,7 @@ lacks the specified property, a type error is thrown.</p>
 </div>
 
 <a class="pilcrow h4" href="#props">¶</a>
-<h4 id="props"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3758">props</a> <span class="tight">:</span><span class="tight">:</span> <a href="#accessible-pseudotype">Accessible</a> a <span class="arrow">=&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> b</code></h4>
+<h4 id="props"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3758">props</a> :: <a href="#accessible-pseudotype">Accessible</a> a => <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> a -> b</code></h4>
 
 <p>Takes a property path (an array of property names) and an object with
 known structure and returns the value at the given path. If for some
@@ -3917,7 +3918,7 @@ instead.</p>
 </div>
 
 <a class="pilcrow h4" href="#get">¶</a>
-<h4 id="get"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3781">get</a> <span class="tight">:</span><span class="tight">:</span> <a href="#accessible-pseudotype">Accessible</a> a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> c</code></h4>
+<h4 id="get"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3781">get</a> :: <a href="#accessible-pseudotype">Accessible</a> a => (b -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> a -> <a href="#MaybeType">Maybe</a> c</code></h4>
 
 <p>Takes a predicate, a property name, and an object and returns Just the
 value of the specified object property if it exists and the value
@@ -3939,7 +3940,7 @@ satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#gets">¶</a>
-<h4 id="gets"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3806">gets</a> <span class="tight">:</span><span class="tight">:</span> <a href="#accessible-pseudotype">Accessible</a> a <span class="arrow">=&gt;</span> (b <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> c</code></h4>
+<h4 id="gets"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3806">gets</a> :: <a href="#accessible-pseudotype">Accessible</a> a => (b -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> a -> <a href="#MaybeType">Maybe</a> c</code></h4>
 
 <p>Takes a predicate, a property path (an array of property names), and
 an object and returns Just the value at the given path if such a path
@@ -3961,7 +3962,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#keys">¶</a>
-<h4 id="keys"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3837">keys</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#StrMap">StrMap</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="keys"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3837">keys</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#StrMap">StrMap</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Returns the keys of the given string map, in arbitrary order.</p>
 <div class="examples">
@@ -3972,7 +3973,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#values">¶</a>
-<h4 id="values"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3847">values</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#StrMap">StrMap</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a</code></h4>
+<h4 id="values"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3847">values</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#StrMap">StrMap</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> a</code></h4>
 
 <p>Returns the values of the given string map, in arbitrary order.</p>
 <div class="examples">
@@ -3983,7 +3984,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#pairs">¶</a>
-<h4 id="pairs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3860">pairs</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#StrMap">StrMap</a> a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Pair">Pair</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> a)</code></h4>
+<h4 id="pairs"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3860">pairs</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#StrMap">StrMap</a> a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Pair">Pair</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> a)</code></h4>
 
 <p>Returns the key–value pairs of the given string map, in arbitrary order.</p>
 <div class="examples">
@@ -3996,7 +3997,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 <a class="pilcrow h3" href="#number">¶</a>
 <h3 id="number">Number</h3>
 <a class="pilcrow h4" href="#negate">¶</a>
-<h4 id="negate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3876">negate</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#ValidNumber">ValidNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#ValidNumber">ValidNumber</a></code></h4>
+<h4 id="negate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3876">negate</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#ValidNumber">ValidNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#ValidNumber">ValidNumber</a></code></h4>
 
 <p>Negates its argument.</p>
 <div class="examples">
@@ -4011,7 +4012,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#add">¶</a>
-<h4 id="add"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3892">add</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
+<h4 id="add"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3892">add</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the sum of two (finite) numbers.</p>
 <div class="examples">
@@ -4022,7 +4023,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sum">¶</a>
-<h4 id="sum"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3906">sum</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> f <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
+<h4 id="sum"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3906">sum</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f => f <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the sum of the given array of (finite) numbers.</p>
 <div class="examples">
@@ -4045,7 +4046,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sub">¶</a>
-<h4 id="sub"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3929">sub</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a>)</code></h4>
+<h4 id="sub"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3929">sub</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> (<a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a>)</code></h4>
 
 <p>Takes a finite number <code>n</code> and returns the <em>subtract <code>n</code></em> function.</p>
 <p>See also <a href="#sub_"><code>sub_</code></a>.</p>
@@ -4057,7 +4058,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#sub_">¶</a>
-<h4 id="sub_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3945">sub_</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
+<h4 id="sub_"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3945">sub_</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the difference between two (finite) numbers.</p>
 <p>See also <a href="#sub"><code>sub</code></a>.</p>
@@ -4069,7 +4070,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#mult">¶</a>
-<h4 id="mult"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3961">mult</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
+<h4 id="mult"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3961">mult</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the product of two (finite) numbers.</p>
 <div class="examples">
@@ -4080,7 +4081,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#product">¶</a>
-<h4 id="product"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3975">product</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> f <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
+<h4 id="product"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L3975">product</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f => f <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the product of the given array of (finite) numbers.</p>
 <div class="examples">
@@ -4103,7 +4104,7 @@ exists and the value satisfies the given predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#div">¶</a>
-<h4 id="div"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4001">div</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#NonZeroFiniteNumber">NonZeroFiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
+<h4 id="div"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4001">div</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#NonZeroFiniteNumber">NonZeroFiniteNumber</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the result of dividing its first argument (a finite number) by
 its second argument (a non-zero finite number).</p>
@@ -4115,7 +4116,7 @@ its second argument (a non-zero finite number).</p>
 </div>
 
 <a class="pilcrow h4" href="#mean">¶</a>
-<h4 id="mean"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4016">mean</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f <span class="arrow">=&gt;</span> f <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
+<h4 id="mean"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4016">mean</a> :: <a href="https://github.com/sanctuary-js/sanctuary-type-classes/tree/v6.0.0#Foldable">Foldable</a> f => f <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a> -> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#FiniteNumber">FiniteNumber</a></code></h4>
 
 <p>Returns the mean of the given array of (finite) numbers.</p>
 <div class="examples">
@@ -4140,7 +4141,7 @@ its second argument (a non-zero finite number).</p>
 <a class="pilcrow h3" href="#integer">¶</a>
 <h3 id="integer">Integer</h3>
 <a class="pilcrow h4" href="#even">¶</a>
-<h4 id="even"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4053">even</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="even"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4053">even</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given integer is even; <code>false</code> if it is odd.</p>
 <div class="examples">
@@ -4155,7 +4156,7 @@ its second argument (a non-zero finite number).</p>
 </div>
 
 <a class="pilcrow h4" href="#odd">¶</a>
-<h4 id="odd"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4069">odd</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="odd"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4069">odd</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Returns <code>true</code> if the given integer is odd; <code>false</code> if it is even.</p>
 <div class="examples">
@@ -4172,7 +4173,7 @@ its second argument (a non-zero finite number).</p>
 <a class="pilcrow h3" href="#parse">¶</a>
 <h3 id="parse">Parse</h3>
 <a class="pilcrow h4" href="#parseDate">¶</a>
-<h4 id="parseDate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4087">parseDate</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Date">Date</a></code></h4>
+<h4 id="parseDate"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4087">parseDate</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Date">Date</a></code></h4>
 
 <p>Takes a string and returns Just the date represented by the string
 if it does in fact represent a date; Nothing otherwise.</p>
@@ -4188,7 +4189,7 @@ if it does in fact represent a date; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#parseFloat">¶</a>
-<h4 id="parseFloat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4139">parseFloat</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Number">Number</a></code></h4>
+<h4 id="parseFloat"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4139">parseFloat</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Number">Number</a></code></h4>
 
 <p>Takes a string and returns Just the number represented by the string
 if it does in fact represent a number; Nothing otherwise.</p>
@@ -4204,7 +4205,7 @@ if it does in fact represent a number; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#parseInt">¶</a>
-<h4 id="parseInt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4157">parseInt</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a></code></h4>
+<h4 id="parseInt"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4157">parseInt</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Integer">Integer</a></code></h4>
 
 <p>Takes a radix (an integer between 2 and 36 inclusive) and a string,
 and returns Just the number represented by the string if it does in
@@ -4229,7 +4230,7 @@ characters are members of the character set specified by the radix.</p>
 </div>
 
 <a class="pilcrow h4" href="#parseJson">¶</a>
-<h4 id="parseJson"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4196">parseJson</a> <span class="tight">:</span><span class="tight">:</span> (a <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> b</code></h4>
+<h4 id="parseJson"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4196">parseJson</a> :: (a -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a>) -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="#MaybeType">Maybe</a> b</code></h4>
 
 <p>Takes a predicate and a string which may or may not be valid JSON, and
 returns Just the result of applying <code>JSON.parse</code> to the string <em>if</em> the
@@ -4252,7 +4253,7 @@ result satisfies the predicate; Nothing otherwise.</p>
 <a class="pilcrow h3" href="#regexp">¶</a>
 <h3 id="regexp">RegExp</h3>
 <a class="pilcrow h4" href="#regex">¶</a>
-<h4 id="regex"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4239">regex</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#RegexFlags">RegexFlags</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#RegExp">RegExp</a></code></h4>
+<h4 id="regex"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4239">regex</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#RegexFlags">RegexFlags</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#RegExp">RegExp</a></code></h4>
 
 <p>Takes a <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#RegexFlags">RegexFlags</a> and a pattern, and returns a RegExp.</p>
 <div class="examples">
@@ -4263,13 +4264,13 @@ result satisfies the predicate; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#regexEscape">¶</a>
-<h4 id="regexEscape"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4252">regexEscape</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="regexEscape"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4252">regexEscape</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Takes a string which may contain regular expression metacharacters,
 and returns a string with those metacharacters escaped.</p>
 <p>Properties:</p>
 <ul>
-<li><code>forall s <span class="tight">:</span><span class="tight">:</span> String. S.test(S.regex(&#39;&#39;, S.regexEscape(s)), s) = true</code></li>
+<li><code>forall s :: String. S.test(S.regex(&#39;&#39;, S.regexEscape(s)), s) = true</code></li>
 </ul>
 <div class="examples">
   <form>
@@ -4279,7 +4280,7 @@ and returns a string with those metacharacters escaped.</p>
 </div>
 
 <a class="pilcrow h4" href="#test">¶</a>
-<h4 id="test"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4270">test</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#RegExp">RegExp</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
+<h4 id="test"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4270">test</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#RegExp">RegExp</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Boolean">Boolean</a></code></h4>
 
 <p>Takes a pattern and a string, and returns <code>true</code> if the pattern
 matches the string; <code>false</code> otherwise.</p>
@@ -4295,15 +4296,15 @@ matches the string; <code>false</code> otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#match">¶</a>
-<h4 id="match"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4287">match</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#NonGlobalRegExp">NonGlobalRegExp</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> { match <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>, groups <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>) }</code></h4>
+<h4 id="match"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4287">match</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#NonGlobalRegExp">NonGlobalRegExp</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="#MaybeType">Maybe</a> { match :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>, groups :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>) }</code></h4>
 
 <p>Takes a pattern and a string, and returns Just a match record if the
 pattern matches the string; Nothing otherwise.</p>
-<p><code>groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String)</code> acknowledges the existence of optional
+<p><code>groups :: Array (Maybe String)</code> acknowledges the existence of optional
 capturing groups.</p>
 <p>Properties:</p>
 <ul>
-<li><code>forall p <span class="tight">:</span><span class="tight">:</span> Pattern, s <span class="tight">:</span><span class="tight">:</span> String.
+<li><code>forall p :: Pattern, s :: String.
  S.head(S.matchAll(S.regex(&#39;g&#39;, p), s)) = S.match(S.regex(&#39;&#39;, p), s)</code></li>
 </ul>
 <p>See also <a href="#matchAll"><code>matchAll</code></a>.</p>
@@ -4319,10 +4320,10 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#matchAll">¶</a>
-<h4 id="matchAll"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4315">matchAll</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#GlobalRegExp">GlobalRegExp</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> { match <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>, groups <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>) }</code></h4>
+<h4 id="matchAll"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4315">matchAll</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#GlobalRegExp">GlobalRegExp</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> { match :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>, groups :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> (<a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a>) }</code></h4>
 
 <p>Takes a pattern and a string, and returns an array of match records.</p>
-<p><code>groups <span class="tight">:</span><span class="tight">:</span> Array (Maybe String)</code> acknowledges the existence of optional
+<p><code>groups :: Array (Maybe String)</code> acknowledges the existence of optional
 capturing groups.</p>
 <p>See also <a href="#match"><code>match</code></a>.</p>
 <div class="examples">
@@ -4339,7 +4340,7 @@ capturing groups.</p>
 <a class="pilcrow h3" href="#string">¶</a>
 <h3 id="string">String</h3>
 <a class="pilcrow h4" href="#toUpper">¶</a>
-<h4 id="toUpper"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4347">toUpper</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="toUpper"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4347">toUpper</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Returns the upper-case equivalent of its argument.</p>
 <p>See also <a href="#toLower"><code>toLower</code></a>.</p>
@@ -4351,7 +4352,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#toLower">¶</a>
-<h4 id="toLower"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4362">toLower</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="toLower"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4362">toLower</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Returns the lower-case equivalent of its argument.</p>
 <p>See also <a href="#toUpper"><code>toUpper</code></a>.</p>
@@ -4363,7 +4364,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#trim">¶</a>
-<h4 id="trim"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4377">trim</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="trim"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4377">trim</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Strips leading and trailing whitespace characters.</p>
 <div class="examples">
@@ -4374,7 +4375,7 @@ capturing groups.</p>
 </div>
 
 <a class="pilcrow h4" href="#stripPrefix">¶</a>
-<h4 id="stripPrefix"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4390">stripPrefix</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="stripPrefix"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4390">stripPrefix</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Returns Just the portion of the given string (the second argument) left
 after removing the given prefix (the first argument) if the string starts
@@ -4392,7 +4393,7 @@ with the prefix; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#stripSuffix">¶</a>
-<h4 id="stripSuffix"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4412">stripSuffix</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="stripSuffix"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4412">stripSuffix</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="#MaybeType">Maybe</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Returns Just the portion of the given string (the second argument) left
 after removing the given suffix (the first argument) if the string ends
@@ -4410,7 +4411,7 @@ with the suffix; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#words">¶</a>
-<h4 id="words"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4434">words</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="words"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4434">words</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Takes a string and returns the array of words the string contains
 (words are delimited by whitespace characters).</p>
@@ -4423,7 +4424,7 @@ with the suffix; Nothing otherwise.</p>
 </div>
 
 <a class="pilcrow h4" href="#unwords">¶</a>
-<h4 id="unwords"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4452">unwords</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="unwords"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4452">unwords</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Takes an array of words and returns the result of joining the words
 with separating spaces.</p>
@@ -4436,7 +4437,7 @@ with separating spaces.</p>
 </div>
 
 <a class="pilcrow h4" href="#lines">¶</a>
-<h4 id="lines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4468">lines</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="lines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4468">lines</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Takes a string and returns the array of lines the string contains
 (lines are delimited by newlines: <code>&#39;\n&#39;</code> or <code>&#39;\r\n&#39;</code> or <code>&#39;\r&#39;</code>).
@@ -4450,7 +4451,7 @@ The resulting strings do not contain newlines.</p>
 </div>
 
 <a class="pilcrow h4" href="#unlines">¶</a>
-<h4 id="unlines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4486">unlines</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="unlines"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4486">unlines</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Takes an array of lines and returns the result of joining the lines
 after appending a terminating line feed (<code>&#39;\n&#39;</code>) to each.</p>
@@ -4463,7 +4464,7 @@ after appending a terminating line feed (<code>&#39;\n&#39;</code>) to each.</p>
 </div>
 
 <a class="pilcrow h4" href="#splitOn">¶</a>
-<h4 id="splitOn"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4502">splitOn</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="splitOn"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4502">splitOn</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Returns the substrings of its second argument separated by occurrences
 of its first argument.</p>
@@ -4476,13 +4477,13 @@ of its first argument.</p>
 </div>
 
 <a class="pilcrow h4" href="#splitOnRegex">¶</a>
-<h4 id="splitOnRegex"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4519">splitOnRegex</a> <span class="tight">:</span><span class="tight">:</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#GlobalRegExp">GlobalRegExp</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> <span class="arrow"><span class="arrow-hyphen">-</span>⁠&gt;</span> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
+<h4 id="splitOnRegex"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.13.2/index.js#L4519">splitOnRegex</a> :: <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#GlobalRegExp">GlobalRegExp</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a> -> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#Array">Array</a> <a href="https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.1#String">String</a></code></h4>
 
 <p>Takes a pattern and a string, and returns the result of splitting the
 string at every non-overlapping occurrence of the pattern.</p>
 <p>Properties:</p>
 <ul>
-<li><code>forall s <span class="tight">:</span><span class="tight">:</span> String, t <span class="tight">:</span><span class="tight">:</span> String.
+<li><code>forall s :: String, t :: String.
  S.joinWith(s, S.splitOnRegex(S.regex(&#39;g&#39;, S.regexEscape(s)), t))
  = t</code></li>
 </ul>

--- a/scripts/generate
+++ b/scripts/generate
@@ -16,7 +16,6 @@ const S_                = require('sanctuary');
 const pkg               = require('sanctuary/package.json');
 const $                 = require('sanctuary-def');
 const Z                 = require('sanctuary-type-classes');
-const type              = require('sanctuary-type-identifiers');
 
 
 const checkTypes        = envvar.boolean('SANCTUARY_CHECK_TYPES', true);
@@ -46,15 +45,14 @@ const contains          = R.contains;
 const converge          = R.converge;
 const curry3            = S.curry3;
 const either            = S.either;
-const elem              = S.elem;
 const encaseEither      = S.encaseEither;
 const encaseEither2_    = S.encaseEither2_;
 const equals            = S.equals;
 const flip_             = S.flip_;
-const fromMaybe         = S.fromMaybe;
 const get               = S.get;
-const head              = S.head;
+const has               = R.has;
 const ifElse            = S.ifElse;
+const init              = R.init;
 const is                = S.is;
 const join              = S.join;
 const joinWith          = S.joinWith;
@@ -63,7 +61,6 @@ const keys              = S.keys;
 const lensProp          = R.lensProp;
 const lift2             = S.lift2;
 const map               = S.map;
-const match             = S.match;
 const matchAll          = S.matchAll;
 const maybe_            = S.maybe_;
 const maybeToEither     = S.maybeToEither;
@@ -74,13 +71,12 @@ const pipe              = S.pipe;
 const prop              = S.prop;
 const reduce            = S.reduce;
 const regex             = S.regex;
-const regexEscape       = S.regexEscape;
 const repeat            = R.repeat;
 const replace           = R.replace;
 const sequence          = S.sequence;
 const slice_            = R.slice;
 const sort              = S.sort;
-const split             = R.split;
+const splitOn           = S.splitOn;
 const splitOnRegex      = S.splitOnRegex;
 const test              = S.test;
 const toString          = S.toString;
@@ -108,7 +104,7 @@ def('fromJust',
 //    j :: Array String -> String
 const j = def('j', {}, [$.Array($.String), $.String], joinWith(''));
 
-//    replace_ :: RegExp -> ([String] -> String) -> String -> String
+//    replace_ :: RegExp -> (Array String -> String) -> String -> String
 const replace_ =
 def('replace_',
     {},
@@ -164,30 +160,59 @@ def('dependencyUrl',
     name => map(concat(`https://github.com/sanctuary-js/${name}/tree/v`),
                 dependencyVersion(name)));
 
+//    externalLink :: String -> String -> String
+const externalLink =
+def('externalLink',
+    {},
+    [$.String, $.String, $.String],
+    (name, s) => el('a', {href: fromJust(dependencyUrl(name)) + '#' + s}, s));
+
 //    linkTokens :: String -> String
 const linkTokens = cond([
-  [s => is(Z.TypeClass, Z[s]),
-   s => {
-     const href = fromJust(dependencyUrl('sanctuary-type-classes')) + '#' + s;
-     return el('a', {href}, s);
-   }],
-  [s => {
-     const x = $[s];
-     const pattern = `^${regexEscape(s)} :: (?:Type -> )*Type$`;
-     return $.test([], $.Type, x) ||
-            type(x) === 'Function' && test(regex('', pattern), String(x));
-   },
-   s => {
-     const href = fromJust(dependencyUrl('sanctuary-def')) + '#' + s;
-     return el('a', {href}, s);
-   }],
+  [test(/^[a-z]$/),      I],
+  [equals(''),           I],
+  [equals('=>'),         I],
+  [equals('~>'),         I],
+  [equals('-\u2060>'),   K('->')],
   [equals('Accessible'), el('a', {href: '#accessible-pseudotype'})],
   [equals('Either'),     el('a', {href: '#EitherType'})],
   [equals('List'),       el('a', {href: '#list'})],
   [equals('Maybe'),      el('a', {href: '#MaybeType'})],
   [equals('TypeRep'),    el('a', {href: '#type-representatives'})],
+  [has(_, $),            externalLink('sanctuary-def')],
+  [has(_, Z),            externalLink('sanctuary-type-classes')],
   [K(true),              I],
 ]);
+
+//    headingToMarkup :: String -> String -> String -> String
+const headingToMarkup =
+def('headingToMarkup',
+    {},
+    [$.String, $.String, $.String, $.String],
+    (id, href, html) => {
+      const [s, t] = reduce(
+        ([s, t, ctx]) => c =>
+          c === ' ' && ctx === '' ?
+            [s + el('a', {href}, t) + c, '', ctx] :
+          c === ':' && (ctx === '' || ctx.endsWith('{')) ?
+            [s + c, '', ctx + ';'] :
+          c === ':' && (ctx === ';' || ctx.endsWith('{;')) ?
+            [s + c, '', init(ctx) + ':'] :
+          c === '(' || c === '[' || c === '{' ?
+            [s + linkTokens(t) + c, '', ctx + c] :
+          c === ')' || c === ']' || c === '}' ?
+            [s + linkTokens(t) + c, '', init(ctx.replace(/:$/, ''))] :
+          c === ',' ?
+            [s + linkTokens(t) + c, '', ctx.replace(/:$/, '')] :
+          c === ' ' || c === '\u00A0' || c === '?' ?
+            [s + (ctx.endsWith('{') ? I : linkTokens)(t) + c, '', ctx] :
+          // else
+            [s, t + c, ctx],
+        ['', '', ''],
+        splitOn('', html)
+      );
+      return el('h4', {id}, el('code', {}, s + linkTokens(t)));
+    });
 
 //    toInputMarkup :: String -> String
 const toInputMarkup =
@@ -235,51 +260,13 @@ def('doctestsToMarkup',
           j,
           wrap('<div class="examples">\n', '</div>\n')]));
 
-//    substitutionPattern :: RegExp
-const substitutionPattern =
-/(<pre>[\s\S]*?<[/]pre>|<div class="examples">[\s\S]*?^<[/]div>| :: |(?:=|~|-\u2060?)(?:&gt;|>)|[.][.][.])/gm;
-
-//    substitutions :: String -> String
-const substitutions =
-def('substitutions',
-    {},
-    [$.String, $.String],
-    replace_(substitutionPattern,
-             apply(cond([[equals(' :: '),
-                          K(' ' +
-                            el('span', {class: 'tight'}, ':') +
-                            el('span', {class: 'tight'}, ':') +
-                            ' ')],
-                         [elem(_, ap([I, htmlEncode], ['=>'])),
-                          K(el('span', {class: 'arrow'}, htmlEncode('=>')))],
-                         [elem(_, ap([I, htmlEncode], ['~>'])),
-                          K(el('span', {class: 'arrow'}, htmlEncode('~>')))],
-                         [elem(_, ap([I, htmlEncode], ['->'])),
-                          K(el('span', {class: 'arrow'},
-                               el('span', {class: 'arrow-hyphen'}, htmlEncode('-'))
-                               + htmlEncode('>')))],
-                         [equals('-\u2060>'),
-                          K(el('span', {class: 'arrow'},
-                               el('span', {class: 'arrow-hyphen'}, htmlEncode('-'))
-                               + htmlEncode('\u2060>')))],
-                         [equals('...'),
-                          K(el('span', {class: 'tight'}, '.') +
-                            el('span', {class: 'tight'}, '.') +
-                            el('span', {class: 'tight'}, '.'))],
-                         [K(true),
-                          I]]))));
-
 //    generate :: String -> String
 const generate =
 def('generate',
     {},
     [$.String, $.String],
-    pipe([replace_(regex('g', '<h4 name="(.*)"><code><a href="(.*)">([^ ]*)(.*)</a></code></h4>'),
-                   ([id, href, name, _innerHtml]) =>
-                     el('h4', {id},
-                        el('code', {},
-                           el('a', {href}, name)
-                           + j(map(linkTokens, split(/(\w+)/, _innerHtml)))))),
+    pipe([replace_(regex('g', '<h4 name="(.*)"><code><a href="(.*)">(.*)</a></code></h4>'),
+                   apply(headingToMarkup)),
           replace_(/^```javascript\n(> [\s\S]*?)^```\n/gm,
                    apply(doctestsToMarkup)),
           //  Replace NO-BREAK SPACE characters with SYMBOL FOR SPACE
@@ -289,8 +276,7 @@ def('generate',
           replace(/\u2420/g, '\u00A0'),
           replace(/\n\n(?=\n<[/]code><[/]pre>)/g, ''),
           replace(/(?=<(h[2-6]) id="([^"]*)")/g,
-                  '<a class="pilcrow $1" href="#$2">\u00B6</a>\n'),
-          substitutions]));
+                  '<a class="pilcrow $1" href="#$2">\u00B6</a>\n')]));
 
 //    readFile :: String -> Either String String
 const readFile =
@@ -368,13 +354,6 @@ def('readme',
 //    pad :: Integer -> String
 const pad = def('pad', {}, [$.Integer, $.String], compose(j, repeat('  ')));
 
-//    colon :: String
-const colon = regexEscape('<span class="tight">:</span>');
-
-//    codeLink :: RegExp
-const codeLink =
-regex('', '^<code><a href="[^"]*">(.*? ' + colon + colon + ' .*)</a></code>$');
-
 //    toc :: String -> String
 const toc =
 def('toc',
@@ -409,14 +388,7 @@ def('toc',
                pad(2 * level$$ - 1) + '</li>\n' +
                pad(2 * level$$ - 1) + '<li>\n' +
                pad(2 * level$$ - 0)) +
-            pipe([match(codeLink),
-                  map(prop('groups')),
-                  chain(head),
-                  join,
-                  map(el('code', {})),
-                  fromMaybe(innerHtml),
-                  el('a', {href: '#' + id})],
-                 innerHtml);
+            el('a', {href: '#' + id}, innerHtml);
 
             return {level: level$$, tagName: hN, html: html$};
           }, {level: 1, tagName: 'h1', html: ''}),
@@ -447,6 +419,7 @@ def('toDocument',
                        location.hash);
     }
   </script>
+  <link rel="stylesheet" href="https://cdn.rawgit.com/tonsky/FiraCode/1.204/distr/fira_code.css">
   <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" href="favicon.png">
   <link rel="mask-icon" href="mask-icon.svg" color="#080">

--- a/style.css
+++ b/style.css
@@ -6,7 +6,9 @@ body {
 }
 
 code {
-  font-family: "Courier", monospace;
+  font-size: 90.476%;
+  line-height: 1.685;
+  font-family: "Fira Code", "Courier", monospace;
   color: #c36;
 }
 
@@ -106,19 +108,18 @@ a code {
   content: "\2013";
 }
 
-#toc code {
-  font-size: 85.714%;
-}
-
-#toc .arrow-hyphen {
-  top: -0.05em;
+#toc code b {
+  font-weight: 500;
 }
 
 pre {
   margin: 1.334em 0;
   padding: 0;
-  font-size: 85.714%;
   line-height: 1.334;
+}
+
+pre code {
+  line-height: 1.474;
 }
 
 .examples {
@@ -128,9 +129,10 @@ pre {
   border-color: #ada;
   background: #efe;
   padding: 0 40px;
-  font-size: 85.714%;
-  line-height: 1.334;
-  font-family: "Courier", monospace;
+  font-size: 76.191%;
+  line-height: 1.5;
+  font-family: "Fira Code", "Courier", monospace;
+  font-variant-ligatures: none;
   color: #666;
 }
 
@@ -150,16 +152,18 @@ pre {
 }
 
 .examples form {
-  margin: 1.334em 0;
+  margin: 1.5em 0;
 }
 
 .examples input {
   display: inline;
+  margin: 0;
   width: 8888px;
   border: none;
   background: none;
   padding: 0;
   font: inherit;
+  font-weight: 500;
   color: #080;
   outline: none;
 }
@@ -171,20 +175,6 @@ pre {
 
 .examples .output[data-error="true"] {
   color: #c36;
-}
-
-.tight + .tight {
-  margin-left: -0.2em;
-}
-
-.arrow {
-  position: relative;
-  top: 0.1em;
-}
-
-.arrow-hyphen {
-  position: relative;
-  top: -0.1em;
 }
 
 h1,
@@ -222,7 +212,12 @@ h1 small {
 }
 
 h4 code {
+  font-weight: 500;
   color: #333;
+}
+
+h4 code a:first-child {
+  font-weight: 700;
 }
 
 p {


### PR DESCRIPTION
[Fira Code][1] is a programming font with [ligatures][2] for numerous operators and symbols.

The `::`, `=>`, and `->` ligatures are particularly useful for Sanctuary as these symbols appear in type signatures throughout the project's documentation. See, for example, the `apFirst` documentation with Courier (above) and Fira Code (below):

<img alt="Before" src="https://user-images.githubusercontent.com/210406/33396462-dcbd51f8-d548-11e7-8bb4-48e088564428.png" width="668" height="194">

<img alt="After" src="https://user-images.githubusercontent.com/210406/33396489-ea5eee3e-d548-11e7-886f-53fafc49c444.png" width="668" height="193">

Note that in addition to the ligatures in the type signature, a ligature is used for `<*`.

Another benefit of using Fira Code is that it's no longer necessary to insert `<span>` elements with class names which are positioned via CSS to achieve pleasing alignment. This simplifies HTML generation and greatly improves the appearance of highlighted type signatures:

<img alt="Before (highlighted)" src="https://user-images.githubusercontent.com/210406/33396474-df404dd6-d548-11e7-812b-e16b72a69907.png" width="668" height="194">

<img alt="After (highlighted)" src="https://user-images.githubusercontent.com/210406/33396492-ec9db018-d548-11e7-9c16-0c44a0231b07.png" width="668" height="193">

Ligatures are a display-level feature which means a search for `Maybe a -> a` will find `fromMaybe` even though its type signature is rendered as `Maybe a → a`. The fact that such low-tech “Hoogle” searches are not possible in the Ramda documentation has frustrated me on several occasions.


[1]: https://github.com/tonsky/FiraCode
[2]: https://en.wikipedia.org/wiki/Typographic_ligature
