### PR TITLE
highlight code blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -901,10 +901,10 @@ disable type checking in certain contexts to avoid paying this cost.
 does not perform type checking.</p>
 <p>In Node, one could use an environment variable to determine whether to
 perform type checking:</p>
-<pre><code class="lang-javascript">const {create, env} = require(&#39;sanctuary&#39;);
+<pre><code class="lang-javascript"><span class="keyword">const</span> {create, env} = require(<span class="string-literal">'sanctuary'</span>);
 
-const checkTypes = process.env.NODE_ENV !== &#39;production&#39;;
-const S = create({checkTypes, env});
+<span class="keyword">const</span> checkTypes = process.env.NODE_ENV !== <span class="string-literal">'production'</span>;
+<span class="keyword">const</span> S = create({checkTypes, env});
 </code></pre>
 <a class="pilcrow h2" href="#api">¶</a>
 <h2 id="api">API</h2>
@@ -921,37 +921,37 @@ is enabled, a badly typed application will produce an exception with a
 descriptive error message.</p>
 <p>The following snippet demonstrates defining a custom type and using
 <code>create</code> to produce a Sanctuary module which is aware of that type:</p>
-<pre><code class="lang-javascript">const {create, env} = require(&#39;sanctuary&#39;);
-const $ = require(&#39;sanctuary-def&#39;);
-const type = require(&#39;sanctuary-type-identifiers&#39;);
+<pre><code class="lang-javascript"><span class="keyword">const</span> {create, env} = require(<span class="string-literal">'sanctuary'</span>);
+<span class="keyword">const</span> $ = require(<span class="string-literal">'sanctuary-def'</span>);
+<span class="keyword">const</span> type = require(<span class="string-literal">'sanctuary-type-identifiers'</span>);
 
-//    Identity :: a -&gt; Identity a
-const Identity = function Identity(x) {
-  if (!(this instanceof Identity)) return new Identity(x);
-  this.value = x;
+<span class="comment">//    Identity :: a -&gt; Identity a</span>
+<span class="keyword">const</span> Identity = <span class="keyword">function</span> Identity(x) {
+  <span class="keyword">if</span> (!(<span class="keyword">this</span> <span class="keyword">instanceof</span> Identity)) <span class="keyword">return</span> <span class="keyword">new</span> Identity(x);
+  <span class="keyword">this</span>.value = x;
 };
 
-Identity[&#39;@@type&#39;] = &#39;my-package/Identity@1&#39;;
+Identity[<span class="string-literal">'@@type'</span>] = <span class="string-literal">'my-package/Identity@1'</span>;
 
-Identity.prototype[&#39;fantasy-land/map&#39;] = function(f) {
-  return Identity(f(this.value));
+Identity.prototype[<span class="string-literal">'fantasy-land/map'</span>] = <span class="keyword">function</span>(f) {
+  <span class="keyword">return</span> Identity(f(<span class="keyword">this</span>.value));
 };
 
-//    IdentityType :: Type -&gt; Type
-const IdentityType = $.UnaryType(
-  Identity[&#39;@@type&#39;],
-  &#39;http://example.com/my-package#Identity&#39;,
-  x =&gt; type(x) === Identity[&#39;@@type&#39;],
+<span class="comment">//    IdentityType :: Type -&gt; Type</span>
+<span class="keyword">const</span> IdentityType = $.UnaryType(
+  Identity[<span class="string-literal">'@@type'</span>],
+  <span class="string-literal">'http://example.com/my-package#Identity'</span>,
+  x =&gt; type(x) === Identity[<span class="string-literal">'@@type'</span>],
   identity =&gt; [identity.value]
 );
 
-const S = create({
-  checkTypes: process.env.NODE_ENV !== &#39;production&#39;,
+<span class="keyword">const</span> S = create({
+  checkTypes: process.env.NODE_ENV !== <span class="string-literal">'production'</span>,
   env: env.concat([IdentityType($.Unknown)]),
 });
 
-S.map(S.sub(1), Identity(43));
-// =&gt; Identity(42)
+S.map(S.sub(<span class="number-literal">1</span>), Identity(<span class="number-literal">43</span>));
+<span class="comment">// =&gt; Identity(42)</span>
 </code></pre>
 <p>See also <a href="#env"><code>env</code></a>.</p>
 <a class="pilcrow h4" href="#env">¶</a>

--- a/scripts/generate
+++ b/scripts/generate
@@ -124,6 +124,17 @@ def('htmlEncode',
           replace(/>/g, '&gt;'),
           replace(/"/g, '&quot;')]));
 
+//    htmlDecode :: String -> String
+const htmlDecode =
+def('htmlDecode',
+    {},
+    [$.String, $.String],
+    pipe([replace(/&#39;/g,  "'"),
+          replace(/&quot;/g, '"'),
+          replace(/&gt;/g,   '>'),
+          replace(/&lt;/g,   '<'),
+          replace(/&amp;/g,  '&')]));
+
 //    wrap :: String -> String -> String -> String
 const wrap =
 def('wrap',
@@ -140,6 +151,13 @@ def('el',
       const attrsHtml = j(map(k => ` ${k}="${attrs[k]}"`, sort(keys(attrs))));
       return `<${tagName}${attrsHtml}>${innerHtml}</${tagName}>`;
     });
+
+//    spanClass :: String -> String -> String
+const spanClass =
+def('spanClass',
+    {},
+    [$.String, $.String, $.String],
+    (className, innerHtml) => el('span', {class: className}, innerHtml));
 
 //    Version :: Type
 const Version =
@@ -267,6 +285,98 @@ def('doctestsToMarkup',
           j,
           wrap('<div class="examples">\n', '</div>\n')]));
 
+//    syntax :: String -> RegExp -> (String -> String) -> String -> String
+const syntax =
+def('syntax',
+    {},
+    [$.String, $.RegExp, Fn($.String, $.String), $.String, $.String],
+    (className, pattern, f, s) =>
+      s.split(pattern).map((s, idx) =>
+        idx % 2 === 0 ? f(s) : spanClass(className, htmlEncode(s))
+      ).join(''));
+
+//    highlightChunk :: String -> String
+const highlightChunk =
+def('highlightChunk',
+    {},
+    [$.String, $.String],
+    syntax('keyword',
+           /\b(const|else|function|if|instanceof|new|return|this)\b/,
+           syntax('boolean-literal',
+                  /\b(false|true)\b/,
+                  syntax('number-literal',
+                         /\b([0-9]+(?:[.][0-9]+)?)\b/,
+                         htmlEncode))));
+
+//    highlight :: String -> String
+const highlight =
+def('highlight',
+    {},
+    [$.String, $.String],
+    _input => {
+      const input = htmlDecode(_input);
+      let output = '';
+      let chunk = '';
+      const $ctx = [];
+      const pop = () => { chunk = ''; $ctx.pop(); };
+      for (let consumed, idx = 0; idx < input.length; idx += consumed.length) {
+        const c = input.charAt(idx);
+        const cc = input.slice(idx, idx + 2);
+        const ctx = $ctx[$ctx.length - 1];
+        if (ctx === '//') {
+          if (c === '\n') {
+            output += spanClass('comment', htmlEncode(chunk)) +
+                      (consumed = c);
+            pop();
+          } else {
+            chunk += consumed = c;
+          }
+        } else if (ctx === "'" || ctx === '"') {
+          if (c === ctx) {
+            output += spanClass('string-literal',
+                                htmlEncode(chunk + (consumed = c)));
+            pop();
+          } else if (c === '\\') {
+            chunk += consumed = cc;
+          } else {
+            chunk += consumed = c;
+          }
+        } else if (ctx === '`') {
+          if (c === ctx) {
+            output += spanClass('template-literal',
+                                htmlEncode(chunk + (consumed = c)));
+            pop();
+          } else if (cc === '${') {
+            output += spanClass('template-literal', htmlEncode(chunk)) +
+                      spanClass('punctuation', htmlEncode(consumed = cc));
+            chunk = '';
+            $ctx.push(cc);
+          } else if (c === '\\') {
+            chunk += consumed = cc;
+          } else {
+            chunk += consumed = c;
+          }
+        } else if (ctx === '${') {
+          if (c === '}') {
+            output += highlightChunk(chunk) +
+                      spanClass('punctuation', consumed = c);
+            pop();
+          } else {
+            chunk += consumed = c;
+          }
+        } else if (cc === '//') {
+          output += highlightChunk(chunk);
+          $ctx.push(chunk = consumed = cc);
+        } else if (c === "'" || c === '"' || c === '`') {
+          output += highlightChunk(chunk);
+          $ctx.push(chunk = consumed = c);
+        } else {
+          chunk += consumed = c;
+        }
+      }
+      return output + highlightChunk(chunk);
+    });
+
 //    generate :: String -> String
 const generate =
 def('generate',
@@ -282,6 +392,8 @@ def('generate',
           s => marked(s, {pedantic: true}),
           replace(/\u2420/g, '\u00A0'),
           replace(/\n\n(?=\n<[/]code><[/]pre>)/g, ''),
+          replace_(regex('g', '(<pre><code class="lang-javascript">)([^]*?)(?=</code></pre>)'),
+                   ([$1, $2]) => $1 + highlight($2)),
           replace(/(?=<(h[2-6]) id="([^"]*)")/g,
                   '<a class="pilcrow $1" href="#$2">\u00B6</a>\n')]));
 

--- a/style.css
+++ b/style.css
@@ -177,6 +177,31 @@ pre code {
   color: #c36;
 }
 
+code.lang-javascript {
+  color: #333;
+}
+
+code.lang-javascript .boolean-literal {
+  color: #963;
+}
+
+code.lang-javascript .comment {
+  color: #999;
+}
+
+code.lang-javascript .keyword {
+  color: #c36;
+}
+
+code.lang-javascript .number-literal {
+  color: #069;
+}
+
+code.lang-javascript .string-literal,
+code.lang-javascript .template-literal {
+  color: #080;
+}
+
 h1,
 h2, .h2,
 h3, .h3,


### PR DESCRIPTION
I :sparkling_heart: the Slack-inspired pink `<code>` elements sprinkled throughout the site, but the two code blocks rendered entirely in pink are a bit much. This pull request adds some fairly simple logic for highlighting `` ```javascript `` code blocks at compile time.

---

### Before

<img alt="Code block before" src="https://user-images.githubusercontent.com/210406/40235052-3f7606ce-5aa9-11e8-9e1e-02f8b3e6221b.png" width="668" height="435" />

---

### After

<img alt="Code block before" src="https://user-images.githubusercontent.com/210406/40235061-45c62716-5aa9-11e8-9cfc-44d87835f8f1.png" width="668" height="435" />
