### PR TITLE
define ‘window.def’

### DIFF
--- a/index.html
+++ b/index.html
@@ -4684,6 +4684,7 @@ string at every non-overlapping occurrence of the pattern.</p>
     window.Cons = window.List.Cons;
     window.env = window.sanctuary.env.concat([List.Type($.Unknown), Sum.Type]);
     window.S = window.sanctuary.create({checkTypes: true, env: env});
+    window.def = $.create({checkTypes: true, env: env});
   </script>
   <script src="behaviour.js"></script>
 </body>

--- a/scripts/generate
+++ b/scripts/generate
@@ -586,6 +586,7 @@ ${content}
     window.Cons = window.List.Cons;
     window.env = window.sanctuary.env.concat([List.Type($.Unknown), Sum.Type]);
     window.S = window.sanctuary.create({checkTypes: true, env: env});
+    window.def = $.create({checkTypes: true, env: env});
   </script>
   <script src="behaviour.js"></script>
 </body>


### PR DESCRIPTION
This change, suggested by @dakom on Gitter, may encourage users to experiment with `def` in the console or in an editable doctest.
