### PR TITLE
behaviour: do not evaluate examples up front

### DIFF
--- a/behaviour.js
+++ b/behaviour.js
@@ -58,14 +58,6 @@
              (evaluate (input.value));
   }
 
-  //  evaluateForms :: Element -> Undefined
-  function evaluateForms(el) {
-    var forms = el.getElementsByTagName ('form');
-    Array.prototype.forEach.call (forms, evaluateForm);
-  }
-
-  evaluateForms (document.body);
-
   //  typeText :: (Element, String, () -> Undefined) -> Undefined
   function typeText(input, text, callback) {
     var shifted = '!"#$%&()*+:<>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_{|}~';
@@ -149,7 +141,10 @@
   document.body.addEventListener ('submit', function(event) {
     if (event.target.tagName === 'FORM') {
       event.preventDefault ();
-      evaluateForms (event.target.parentNode);
+      Array.prototype.forEach.call (
+        event.target.parentNode.getElementsByTagName ('form'),
+        evaluateForm
+      );
     }
   }, false);
 


### PR DESCRIPTION
I believe I decided to call `evaluateForm` for each `<form>` up front to hide discrepancies in the wording of error messages in different environments. For example:

```javascript
> process.version
'v10.4.0'

> S.encaseEither (S.I) (JSON.parse) ('[')
Left (new SyntaxError ('Unexpected end of JSON input'))
```

```javascript
> navigator.userAgent
'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.1 Safari/605.1.15'

> S.encaseEither (S.I) (JSON.parse) ('[')
Left (new SyntaxError ('JSON Parse error: Unexpected EOF'))
```

Evaluating hundreds of tiny JavaScript programs takes time (about 1.5 seconds for me on an iMac Pro). It's unreasonable to force a delay upon every visitor to the site just to “correct” a couple of examples.
