### PR TITLE
generate: introduce Html type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ clean:
 .PHONY: lint
 lint:
 	$(ESLINT) --config node_modules/sanctuary-style/eslint-es6.json -- scripts/generate
-	$(ESLINT) -- behaviour.js adt/List.js adt/Sum.js env.js
+	$(ESLINT) -- behaviour.js env.js $(ADT)
 	make clean
 	make
 	git diff --exit-code

--- a/adt/Html.js
+++ b/adt/Html.js
@@ -1,0 +1,97 @@
+(function(f) {
+
+  'use strict';
+
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = f (require ('sanctuary-def'),
+                        require ('sanctuary-show'),
+                        require ('sanctuary-type-identifiers'));
+  } else {
+    self.Html = f (self.sanctuaryDef,
+                   self.sanctuaryShow,
+                   self.sanctuaryTypeIdentifiers);
+  }
+
+} (function($, show, type) {
+
+  'use strict';
+
+  var def = $.create ({checkTypes: true, env: []});
+
+  var HtmlType = $.NullaryType
+    ('sanctuary-site/Html')
+    ('https://github.com/sanctuary-js/sanctuary-site/blob/gh-pages/adt/Html.js')
+    (function(x) { return type (x) === Html['@@type']; });
+
+  //  Html :: String -> Html
+  var Html =
+  def ('Html')
+      ({})
+      ([$.String, HtmlType])
+      (function(s) {
+         var html = Object.create (Html$prototype);
+         html.value = s;
+         return html;
+       });
+
+  var Html$prototype = {
+    'constructor': Html,
+    'fantasy-land/concat': function(other) {
+      return Html (this.value + other.value);
+    },
+    '@@show': function() {
+      return 'Html (' + show (this.value) + ')';
+    }
+  };
+
+  Html['@@type'] = 'sanctuary-site/Html';
+
+  Html['fantasy-land/empty'] = function() { return Html (''); };
+
+  //  Html.unwrap :: Html -> String
+  Html.unwrap =
+  def ('Html.unwrap')
+      ({})
+      ([HtmlType, $.String])
+      (function(html) { return html.value; });
+
+  //  Html.encode :: String -> Html
+  Html.encode =
+  def ('Html.encode')
+      ({})
+      ([$.String, HtmlType])
+      (function(text) {
+         return Html (text.replace (/&/g, '&amp;')
+                          .replace (/</g, '&lt;')
+                          .replace (/"/g, '&quot;'));
+       });
+
+  //  Html.decode :: Html -> String
+  Html.decode =
+  def ('Html.decode')
+      ({})
+      ([HtmlType, $.String])
+      (function(html) {
+         return html.value
+                    .replace (/&quot;/g, '"')
+                    .replace (/&lt;/g,   '<')
+                    .replace (/&amp;/g,  '&');
+       });
+
+  //  Html.indent :: NonNegativeInteger -> Html -> Html
+  Html.indent =
+  def ('Html.indent')
+      ({})
+      ([$.NonNegativeInteger, HtmlType, HtmlType])
+      (function(indent) {
+         return function(html) {
+           return Html (html.value.replace (/^(?!$)/gm, ' '.repeat (indent)));
+         };
+       });
+
+  //  Html.Type :: Type
+  Html.Type = HtmlType;
+
+  return Html;
+
+}));

--- a/env.js
+++ b/env.js
@@ -11,6 +11,7 @@
                         require ('sanctuary-identity'),
                         require ('sanctuary-type-classes'),
                         require ('sanctuary-type-identifiers'),
+                        require ('./adt/Html.js'),
                         require ('./adt/List.js'),
                         require ('./adt/Sum.js'));
   } else {
@@ -20,11 +21,12 @@
                   self.sanctuaryIdentity,
                   self.sanctuaryTypeClasses,
                   self.sanctuaryTypeIdentifiers,
+                  self.Html,
                   self.List,
                   self.Sum);
   }
 
-} (function(S, $, Descending, Identity, Z, type, List, Sum) {
+} (function(S, $, Descending, Identity, Z, type, Html, List, Sum) {
 
   'use strict';
 
@@ -71,6 +73,7 @@
 
   return S.env.concat ([
     DescendingType ($.Unknown),
+    Html.Type,
     IdentityType ($.Unknown),
     ListType ($.Unknown),
     SumType

--- a/index.html
+++ b/index.html
@@ -4046,6 +4046,7 @@ string at every non-overlapping occurrence of the pattern.</p>
   <script src="vendor/sanctuary-maybe.js"></script>
   <script src="vendor/sanctuary-pair.js"></script>
   <script src="vendor/sanctuary-def.js"></script>
+  <script src="adt/Html.js"></script>
   <script src="adt/List.js"></script>
   <script src="adt/Sum.js"></script>
   <script src="vendor/sanctuary.js"></script>

--- a/scripts/generate
+++ b/scripts/generate
@@ -18,6 +18,7 @@ const Descending        = require ('sanctuary-descending');
 const show              = require ('sanctuary-show');
 const Z                 = require ('sanctuary-type-classes');
 
+const Html              = require ('../adt/Html');
 const List              = require ('../adt/List');
 const Sum               = require ('../adt/Sum');
 const env               = require ('../env');
@@ -42,37 +43,36 @@ const concat            = S.concat;
 const cond              = R.cond;
 const curry2            = S.curry2;
 const either            = S.either;
+const empty             = S.empty;
 const encaseEither      = S.encaseEither;
 const encaseEither2     = S.encaseEither2;
 const equals            = S.equals;
 const flip              = S.flip;
+const fst               = S.fst;
 const get               = S.get;
 const has               = R.has;
 const ifElse            = S.ifElse;
-const init              = R.init;
 const is                = S.is;
 const join              = S.join;
-const joinWith          = S.joinWith;
-const keys              = S.keys;
 const lift2             = S.lift2;
 const map               = S.map;
 const matchAll          = S.matchAll;
 const maybe_            = S.maybe_;
 const maybeToEither     = S.maybeToEither;
 const of                = S.of;
-const pair              = R.pair;
+const on                = S.on;
+const pairs             = S.pairs;
 const pipe              = S.pipe;
 const prop              = S.prop;
 const reduce            = S.reduce;
 const regex             = S.regex;
 const replace           = R.replace;
 const sequence          = S.sequence;
-const singleton         = S.singleton;
+const snd               = S.snd;
 const sort              = S.sort;
 const splitOn           = S.splitOn;
 const splitOnRegex      = S.splitOnRegex;
 const test              = S.test;
-const unlines           = S.unlines;
 const when              = S.when;
 
 const reset             = '\u001B[0m';
@@ -92,51 +92,48 @@ def ('fromJust')
     ([Maybe (a), a])
     (maybe_ (() => { throw new Error ('fromJust applied to Nothing'); }) (I));
 
-//    j :: Array String -> String
-const j = def ('j') ({}) ([$.Array ($.String), $.String]) (joinWith (''));
-
-//    htmlEncode :: String -> String
-const htmlEncode =
-def ('htmlEncode')
-    ({})
-    ([$.String, $.String])
-    (pipe ([replace (/&/g) ('&amp;'),
-            replace (/</g) ('&lt;'),
-            replace (/"/g) ('&quot;')]));
-
-//    htmlDecode :: String -> String
-const htmlDecode =
-def ('htmlDecode')
-    ({})
-    ([$.String, $.String])
-    (pipe ([replace (/&quot;/g) ('"'),
-            replace (/&lt;/g)   ('<'),
-            replace (/&amp;/g)  ('&')]));
-
-//    wrap :: String -> String -> String -> String
+//    wrap :: Semigroup a => a -> a -> a -> a
 const wrap =
 def ('wrap')
-    ({})
-    ([$.String, $.String, $.String, $.String])
-    (before => after => middle => `${before}${middle}${after}`);
+    ({a: [Z.Semigroup]})
+    ([a, a, a, a])
+    (before => after => middle => concat (concat (before) (middle)) (after));
 
-//    el :: String -> StrMap String -> String -> String
+//    el :: String -> StrMap String -> Html -> Html
 const el =
 def ('el')
     ({})
-    ([$.String, $.StrMap ($.String), $.String, $.String])
-    (tagName => attrs =>
-       wrap (`<${tagName}` +
-             j (map (k => ` ${k}="${attrs[k]}"`) (sort (keys (attrs)))) +
-             '>')
-            (`</${tagName}>`));
+    ([$.String, $.StrMap ($.String), Html.Type, Html.Type])
+    (tagName => attrs => html =>
+       reduce (concat)
+              (empty (Html))
+              (join ([[Html (`<${tagName}`)],
+                      chain (pair => [Html (' '),
+                                      Html.encode (fst (pair)),
+                                      Html ('='),
+                                      Html ('"'),
+                                      Html.encode (snd (pair)),
+                                      Html ('"')])
+                            (sort (pairs (attrs))),
+                      [Html ('>')],
+                      [html],
+                      [Html (`</${tagName}>`)]])));
 
-//    spanClass :: String -> String -> String
+//    anchor :: String -> String -> Html
+const anchor =
+def ('anchor')
+    ({})
+    ([$.String, $.String, Html.Type])
+    (href => text => el ('a') ({href}) (Html.encode (text)));
+
+//    spanClass :: String -> String -> Html
 const spanClass =
 def ('spanClass')
     ({})
-    ([$.String, $.String, $.String])
-    (compose (el ('span')) (singleton ('class')));
+    ([$.String, $.String, Html.Type])
+    (className => text => el ('span')
+                             ({class: className})
+                             (Html.encode (text)));
 
 //    Version :: Type
 const Version = $.NullaryType
@@ -159,69 +156,73 @@ def ('dependencyUrl')
     (name => map (concat (`https://github.com/sanctuary-js/${name}/tree/v`))
                  (dependencyVersion (name)));
 
-//    externalLink :: String -> String -> String
+//    externalLink :: String -> String -> Html
 const externalLink =
 def ('externalLink')
     ({})
-    ([$.String, $.String, $.String])
-    (name => s => el ('a')
-                     ({href: fromJust (dependencyUrl (name)) + '#' + s})
-                     (s));
+    ([$.String, $.String, Html.Type])
+    (name => s => anchor (fromJust (dependencyUrl (name)) + '#' + s) (s));
 
-//    linkTokens :: String -> String
-const linkTokens = cond ([
-  [test (/^[a-z]$/),     I],
-  [equals (''),          I],
-  [equals ('=>'),        I],
-  [equals ('~>'),        I],
-  [equals ('-\u2060>'),  K ('->')],
-  [equals ('Either'),    el ('a') ({href: '#EitherType'})],
-  [equals ('Maybe'),     el ('a') ({href: '#MaybeType'})],
-  [equals ('Pair'),      el ('a') ({href: '#PairType'})],
-  [equals ('TypeRep'),   el ('a') ({href: 'https://github.com/fantasyland/fantasy-land#type-representatives'})],
-  [flip (has) ($),       externalLink ('sanctuary-def')],
-  [flip (has) (Z),       externalLink ('sanctuary-type-classes')],
-  [K (true),             I],
-]);
+//    linkTokens :: String -> Html
+const linkTokens =
+def ('linkTokens')
+    ({})
+    ([$.String, Html.Type])
+    (cond ([[test (/^[a-z]$/),     Html.encode],
+            [equals (''),          Html.encode],
+            [equals ('=>'),        Html.encode],
+            [equals ('~>'),        Html.encode],
+            [equals ('-\u2060>'),  K (Html.encode ('->'))],
+            [equals ('Either'),    anchor ('#EitherType')],
+            [equals ('Maybe'),     anchor ('#MaybeType')],
+            [equals ('Pair'),      anchor ('#PairType')],
+            [equals ('TypeRep'),   anchor ('https://github.com/fantasyland/fantasy-land#type-representatives')],
+            [flip (has) ($),       externalLink ('sanctuary-def')],
+            [flip (has) (Z),       externalLink ('sanctuary-type-classes')],
+            [K (true),             Html.encode]]));
 
-//    headingToMarkup :: String -> String -> String -> String
+//    headingToMarkup :: String -> String -> String -> Html
 const headingToMarkup =
 def ('headingToMarkup')
     ({})
-    ([$.String, $.String, $.String, $.String])
+    ([$.String, $.String, $.String, Html.Type])
     (id => href => text => {
-       const [s, t] = reduce
-         (([s, t, ctx]) => c =>
+       const {t, html} = reduce
+         (({t, html, ctx}) => c =>
             c === ' ' && ctx === '' ?
-              [s + el ('a') ({href}) (t) + c, '', ctx] :
+              {t: '', html: wrap (html) (Html.encode (c)) (anchor (href) (t)), ctx} :
             c === ':' && (ctx === '' || ctx.endsWith ('{')) ?
-              [s + c, '', ctx + ';'] :
+              {t: '', html: concat (html) (Html.encode (c)), ctx: ctx + ';'} :
             c === ':' && (ctx === ';' || ctx.endsWith ('{;')) ?
-              [s + c, '', init (ctx) + ':'] :
+              {t: '', html: concat (html) (Html.encode (c)), ctx: ctx.slice (0, -1) + ':'} :
             c === '(' || c === '[' || c === '{' ?
-              [s + linkTokens (t) + c, '', ctx + c] :
+              {t: '', html: wrap (html) (Html.encode (c)) (linkTokens (t)), ctx: ctx + c} :
             c === ')' || c === ']' || c === '}' ?
-              [s + linkTokens (t) + c, '', init (ctx.replace (/:$/, ''))] :
+              {t: '', html: wrap (html) (Html.encode (c)) (linkTokens (t)), ctx: (ctx.replace (/:$/, '')).slice (0, -1)} :
             c === ',' ?
-              [s + linkTokens (t) + c, '', ctx.replace (/:$/, '')] :
+              {t: '', html: wrap (html) (Html.encode (c)) (linkTokens (t)), ctx: ctx.replace (/:$/, '')} :
             c === ' ' || c === '\u00A0' || c === '?' ?
-              [s + (ctx.endsWith ('{') ? I : linkTokens) (t) + c, '', ctx] :
+              {t: '', html: wrap (html) (Html.encode (c)) ((ctx.endsWith ('{') ? Html.encode : linkTokens) (t)), ctx} :
             // else
-              [s, t + c, ctx])
-         (['', '', ''])
-         (splitOn ('') (htmlEncode (text)));
+              {t: t + c, html, ctx})
+         ({t: '', html: empty (Html), ctx: ''})
+         (splitOn ('') (text));
 
-       return el ('h4') ({id}) (el ('code') ({}) (s + linkTokens (t)));
+       return el ('h4')
+                 ({id})
+                 (el ('code')
+                     ({})
+                     (concat (html) (linkTokens (t))));
      });
 
-//    toInputMarkup :: String -> String
+//    toInputMarkup :: String -> Html
 const toInputMarkup =
 def ('toInputMarkup')
     ({})
-    ([$.String, $.String])
-    (pipe ([htmlEncode,
-            wrap ('<input value="') ('">'),
-            concat (htmlEncode ('>\u00A0'))]));
+    ([$.String, Html.Type])
+    (pipe ([Html.encode,
+            wrap (Html ('<input value="')) (Html ('">')),
+            concat (Html.encode ('>\u00A0'))]));
 
 //    $context :: ContextifiedSandbox
 const $context = (() => {
@@ -231,28 +232,28 @@ const $context = (() => {
   return vm.createContext ({$, Cons, Descending, List, Nil, R, S, Sum});
 }) ();
 
-//    toOutputMarkup :: String -> String
+//    toOutputMarkup :: String -> Html
 const toOutputMarkup =
 def ('toOutputMarkup')
     ({})
-    ([$.String, $.String])
+    ([$.String, Html.Type])
     (pipe ([encaseEither (prop ('message'))
                          (code => vm.runInContext (code,
                                                    $context,
                                                    {displayErrors: false})),
             either (pipe ([concat ('! '),
-                           htmlEncode,
+                           Html.encode,
                            el ('div') ({'class': 'output',
                                         'data-error': 'true'})]))
                    (pipe ([show,
-                           htmlEncode,
+                           Html.encode,
                            el ('div') ({'class': 'output'})]))]));
 
-//    doctestsToMarkup :: String -> String
+//    doctestsToMarkup :: String -> Html
 const doctestsToMarkup =
 def ('doctestsToMarkup')
     ({})
-    ([$.String, $.String])
+    ([$.String, Html.Type])
     (pipe ([matchAll (/^> .*(?:\n[.] .*)*/gm),
             map (prop ('match')),
             map (replace (/\[\n[.] */g) ('[')),
@@ -261,45 +262,49 @@ def ('doctestsToMarkup')
             map (replace (/^ +/gm) (' ')),
             map (replace (/\n/g) ('')),
             map (replace (/^global[.]/) ('const ')),
-            map (lift2 (pair) (toInputMarkup) (toOutputMarkup)),
-            map (map (concat ('    '))),
-            map (unlines),
-            map (wrap ('  <form>\n') ('  </form>\n')),
-            j,
-            wrap ('<div class="examples">\n') ('</div>\n')]));
+            map (lift2 (on (concat) (wrap (Html ('    ')) (Html ('\n'))))
+                       (toInputMarkup)
+                       (toOutputMarkup)),
+            map (wrap (Html ('  <form>\n')) (Html ('  </form>\n'))),
+            reduce (concat) (empty (Html)),
+            wrap (Html ('<div class="examples">\n')) (Html ('</div>\n'))]));
 
-//    syntax :: String -> RegExp -> (String -> String) -> String -> String
+//    syntax :: String -> RegExp -> (String -> Html) -> String -> Html
 const syntax =
 def ('syntax')
     ({})
-    ([$.String, $.RegExp, Fn ($.String) ($.String), $.String, $.String])
+    ([$.String, $.RegExp, Fn ($.String) (Html.Type), $.String, Html.Type])
     (className => pattern => f => s =>
-       j (s.split (pattern)
-           .map ((s, idx) =>
-                   idx % 2 === 0 ? f (s)
-                                 : spanClass (className) (htmlEncode (s)))));
+       prop ('html')
+            (reduce (({highlight, html}) => s => ({
+                       highlight: !highlight,
+                       html: concat (html)
+                                    ((highlight ? spanClass (className) : f) (s)),
+                     }))
+                    ({highlight: false, html: empty (Html)})
+                    (s.split (pattern))));
 
-//    highlightChunk :: String -> String
+//    highlightChunk :: String -> Html
 const highlightChunk =
 def ('highlightChunk')
     ({})
-    ([$.String, $.String])
+    ([$.String, Html.Type])
     (syntax ('keyword')
             (/\b(const|else|function|if|instanceof|new|return|this)\b/)
             (syntax ('boolean-literal')
                     (/\b(false|true)\b/)
                     (syntax ('number-literal')
                             (/\b([0-9]+(?:[.][0-9]+)?)\b/)
-                            (htmlEncode))));
+                            (Html.encode))));
 
-//    highlight :: String -> String
+//    highlight :: Html -> Html
 const highlight =
 def ('highlight')
     ({})
-    ([$.String, $.String])
+    ([Html.Type, Html.Type])
     (_input => {
-       const input = htmlDecode (_input);
-       let output = '';
+       const input = Html.decode (_input);
+       let output = empty (Html);
        let chunk = '';
        const $ctx = [];
        const pop = () => { chunk = ''; $ctx.pop (); };
@@ -309,16 +314,18 @@ def ('highlight')
          const ctx = $ctx[$ctx.length - 1];
          if (ctx === '//') {
            if (c === '\n') {
-             output += spanClass ('comment') (htmlEncode (chunk)) +
-                       (consumed = c);
+             output = wrap (output)
+                           (Html.encode (consumed = c))
+                           (spanClass ('comment') (chunk));
              pop ();
            } else {
              chunk += consumed = c;
            }
          } else if (ctx === "'" || ctx === '"') {
            if (c === ctx) {
-             output += spanClass ('string-literal')
-                                 (htmlEncode (chunk + (consumed = c)));
+             output = concat (output)
+                             (spanClass ('string-literal')
+                                        (chunk + (consumed = c)));
              pop ();
            } else if (c === '\\') {
              chunk += consumed = cc;
@@ -327,12 +334,14 @@ def ('highlight')
            }
          } else if (ctx === '`') {
            if (c === ctx) {
-             output += spanClass ('template-literal')
-                                 (htmlEncode (chunk + (consumed = c)));
+             output = concat (output)
+                             (spanClass ('template-literal')
+                                        (chunk + (consumed = c)));
              pop ();
            } else if (cc === '${') {
-             output += spanClass ('template-literal') (htmlEncode (chunk)) +
-                       spanClass ('punctuation') (htmlEncode (consumed = cc));
+             output = wrap (output)
+                           (spanClass ('punctuation') (consumed = cc))
+                           (spanClass ('template-literal') (chunk));
              chunk = '';
              $ctx.push (cc);
            } else if (c === '\\') {
@@ -342,34 +351,35 @@ def ('highlight')
            }
          } else if (ctx === '${') {
            if (c === '}') {
-             output += highlightChunk (chunk) +
-                       spanClass ('punctuation') (consumed = c);
+             output = wrap (output)
+                           (spanClass ('punctuation') (consumed = c))
+                           (highlightChunk (chunk));
              pop ();
            } else {
              chunk += consumed = c;
            }
          } else if (cc === '//') {
-           output += highlightChunk (chunk);
+           output = concat (output) (highlightChunk (chunk));
            $ctx.push (chunk = consumed = cc);
          } else if (c === "'" || c === '"' || c === '`') {
-           output += highlightChunk (chunk);
+           output = concat (output) (highlightChunk (chunk));
            $ctx.push (chunk = consumed = c);
          } else {
            chunk += consumed = c;
          }
        }
-       return output + highlightChunk (chunk);
+       return concat (output) (highlightChunk (chunk));
      });
 
-//    generate :: String -> String
+//    generate :: String -> Html
 const generate =
 def ('generate')
     ({})
-    ([$.String, $.String])
+    ([$.String, Html.Type])
     (pipe ([replace (regex ('gm') ('^#### <a name="(.*)" href="(.*)">`(.*)`</a>$'))
-                    (($0, $1, $2, $3) => headingToMarkup ($1) ($2) ($3)),
+                    (($0, $1, $2, $3) => Html.unwrap (headingToMarkup ($1) ($2) ($3))),
             replace (regex ('gm') ('^```javascript\\n(> [^]*?)^```\\n'))
-                    (($0, $1) => doctestsToMarkup ($1)),
+                    (($0, $1) => Html.unwrap (doctestsToMarkup ($1))),
             //  Replace NO-BREAK SPACE characters with SYMBOL FOR SPACE
             //  characters to work around chjj/marked#363.
             replace (/\u00A0/g) ('\u2420'),
@@ -379,9 +389,10 @@ def ('generate')
             replace (/&gt;/g) ('>'),
             replace (/\n\n(?=\n<[/]code><[/]pre>)/g) (''),
             replace (regex ('g') ('(<pre><code class="lang-javascript">)([^]*?)(?=</code></pre>)'))
-                    (($0, $1, $2) => $1 + highlight ($2)),
+                    (($0, $1, $2) => $1 + Html.unwrap (highlight (Html ($2)))),
             replace (/(?=<(h[2-6]) id="([^"]*)")/g)
-                    ('<a class="pilcrow $1" href="#$2">\u00B6</a>\n')]));
+                    ('<a class="pilcrow $1" href="#$2">\u00B6</a>\n'),
+            Html]));
 
 //    readFile :: String -> Either String String
 const readFile =
@@ -396,7 +407,7 @@ def ('writeFile')
     ({})
     ([$.String, $.String, Either ($.String) ($.String)])
     (filename => s =>
-       map (S.K (filename))
+       map (K (filename))
            (encaseEither2 (prop ('message'))
                           (curry2 (fs.writeFileSync))
                           (filename)
@@ -458,6 +469,7 @@ def ('readme')
             ap (customize ('custom/split-on-regex.md')),
             join,
             map (generate),
+            map (Html.unwrap),
             map (concat ('\n')),
             map (replace (/\n$/) (''))]));
 
@@ -465,78 +477,81 @@ def ('readme')
 const Heading = $.RecordType ({
   level: $.PositiveInteger,
   id: $.String,
-  html: $.String,
+  html: Html.Type,
   subheads: $.Array ($.NullaryType ('Heading')
                                    ('')
                                    (x => $.test ([]) (Heading) (x))),
 });
 
-//    tocListItem :: Heading -> String
+//    tocListItem :: Heading -> Html
 const tocListItem =
 def ('tocListItem')
     ({})
-    ([Heading, $.String])
+    ([Heading, Html.Type])
     (function recur({level, id, html, subheads}) {
-       const indent = ' '.repeat (level * (level - 1) + 4);
        const a = el ('a')
                     ({href: '#' + id})
-                    (html.replace (/<a [^>]*>([^<]*)<[/]a>/g,
-                                   ($0, $1, idx) =>
-                                     when (K (idx === '<code>'.length))
-                                          (wrap ('<b>') ('</b>'))
-                                          ($1)));
-       return wrap (`${indent}<li>\n`)
-                   (`${indent}</li>\n`)
-                   (subheads.length === 0 ?
-                      wrap (`${indent}  `) ('\n') (a) :
-                    level < 3 ?
-                      wrap (`${indent}  ${a}\n` +
-                            `${indent}  <ul>\n`)
-                           (`${indent}  </ul>\n`)
-                           (j (map (recur) (subheads))) :
-                    // else
-                      wrap (`${indent}  <details>\n` +
-                            `${indent}    <summary>${a}</summary>\n` +
-                            `${indent}    <ul>\n`)
-                           (`${indent}    </ul>\n` +
-                            `${indent}  </details>\n`)
-                           (j (map (recur) (subheads))));
+                    (Html (Html.unwrap (html)
+                           .replace (/<a [^>]*>([^<]*)<[/]a>/g,
+                                     ($0, $1, idx) =>
+                                       when (K (idx === '<code>'.length))
+                                            (wrap ('<b>') ('</b>'))
+                                            ($1))));
+       return Html.indent (4) (reduce (concat) (empty (Html)) (join (join ([
+         [[Html ('<li>\n')]],
+         subheads.length === 0 ?
+           [[Html ('  '), a, Html ('\n')]] :
+         level < 3 ?
+           [[Html ('  '), a, Html ('\n')],
+            [Html ('  <ul>\n')],
+            map (recur) (subheads),
+            [Html ('  </ul>\n')]] :
+         // else
+           [[Html ('  <details>\n')],
+            [Html ('    <summary>'), a, Html ('</summary>\n')],
+            [Html ('    <ul>\n')],
+            map (compose (Html.indent (2)) (recur)) (subheads),
+            [Html ('    </ul>\n')],
+            [Html ('  </details>\n')]],
+         [[Html ('</li>\n')]],
+       ]))));
      });
 
-//    toc :: String -> String
+//    toc :: String -> Html
 const toc =
 def ('toc')
     ({})
-    ([$.String, $.String])
+    ([$.String, Html.Type])
     (pipe ([matchAll (/<(h[1-6]) id="([^"]*)">(.*)<[/]\1>/g),
             map (prop ('groups')),
             map (map (fromJust)),
-            reduce (heading => ([tagName, id, html]) => {
+            reduce (heading => ([tagName, id, s]) => {
                       const level = Number (replace ('h', '', tagName));
                       for (let subheads = heading.subheads;
                            true;
                            subheads = subheads[subheads.length - 1].subheads) {
                         if (subheads.length === 0 ||
                             subheads[0].level === level) {
-                          subheads.push ({level, id, html, subheads: []});
+                          subheads.push ({level, id, html: Html (s), subheads: []});
                           return heading;
                         }
                       }
                     })
-                   ({level: 1, id: '', html: '', subheads: []}),
+                   ({level: 1, id: '', html: empty (Html), subheads: []}),
             prop ('subheads'),
             map (tocListItem),
-            j,
-            wrap ('    <ul id="toc">\n')
-                 ('    </ul>'),
-            concat ('\n')]));
+            reduce (concat) (empty (Html)),
+            wrap (Html ('  <ul id="toc">\n'))
+                 (Html ('  </ul>')),
+            Html.indent (2),
+            concat (Html ('\n'))]));
 
-//    toDocument :: String -> String -> String -> String
+//    toDocument :: String -> String -> String -> Html
 const toDocument =
 def ('toDocument')
     ({})
-    ([$.String, $.String, $.String, $.String])
-    (version => tagline => content => `<!doctype html>
+    ([$.String, $.String, $.String, Html.Type])
+    (version => tagline => content => Html (`<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -566,7 +581,7 @@ def ('toDocument')
   <div id="css-main">
     <h1 id="sanctuary">Sanctuary <small>v${version}</small></h1>
     <p id="tagline">${tagline}</p>
-${toc (content)}
+${Html.unwrap (toc (content))}
 ${content}
   </div>
   <script src="vendor/ramda.js"></script>
@@ -579,6 +594,7 @@ ${content}
   <script src="vendor/sanctuary-maybe.js"></script>
   <script src="vendor/sanctuary-pair.js"></script>
   <script src="vendor/sanctuary-def.js"></script>
+  <script src="adt/Html.js"></script>
   <script src="adt/List.js"></script>
   <script src="adt/Sum.js"></script>
   <script src="vendor/sanctuary.js"></script>
@@ -598,7 +614,7 @@ ${content}
   <script src="behaviour.js"></script>
 </body>
 </html>
-`);
+`));
 
 //    failure :: String -> Undefined
 const failure = s => {
@@ -618,7 +634,7 @@ pipe ([at (2),
        map (ap ([version, description, readme])),
        chain (sequence (S.Either)),
        map (([version, tagline, content]) =>
-              toDocument (version) (tagline) (content)),
+              Html.unwrap (toDocument (version) (tagline) (content))),
        chain (writeFile ('index.html')),
        either (failure) (success)])
      (process.argv);


### PR DESCRIPTION
[`generate`][1] deals with many `String` values: some represent HTML; some represent text which must be encoded for inclusion in the HTML document. It's not easy to keep track of which strings are which.

Fortunately we have a tool for making such distinctions and verifying the correctness of our programs. This pull request introduces the `Html` type and updates the signatures of many internal functions to make use of it. This makes it clear whether a particular argument is expected to be HTML-encoded.

> ```diff
> -//    el :: String -> StrMap String -> String -> String
> +//    el :: String -> StrMap String -> Html -> Html
> ```

The new type tells us that `el` expects an HTML-encoded body along with unencoded attribute values.

```console
$ grep ' :: ' adt/Html.js
  //  Html :: String -> Html
  //  Html.unwrap :: Html -> String
  //  Html.encode :: String -> Html
  //  Html.decode :: Html -> String
  //  Html.indent :: NonNegativeInteger -> Html -> Html
  //  Html.Type :: Type
```

This pull request replaces `htmlEncode` and `htmlDecode` with `Html.encode` and `Html.decode` whose types convey more information.

`Html` is the sole data constructor of the `Html` type. It permits tags to appear in `Html` values, as in `Html ('<b>')`. `Html.unwrap` is the inverse, providing access to the wrapped HTML string.


[1]: https://github.com/sanctuary-js/sanctuary-site/blob/gh-pages/scripts/generate
