### PR TITLE
style: specify text-size-adjust to normalize text size on iPhone

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,6 +2,9 @@ body {
   margin: 0;
   padding: 0 40px;
   font: 21px/1.524 "Avenir Next", "Avenir", sans-serif;
+  -ms-text-size-adjust: 150%;
+  -webkit-text-size-adjust: 150%;
+  text-size-adjust: 150%;
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
### Before

The input text is much smaller than the output text, and the pilcrow (¶) is smaller than the heading text.

<img width="964" alt="iPhone X rendering before" src="https://user-images.githubusercontent.com/210406/41823223-cd7cd680-77fc-11e8-92c3-434feff42aaa.png">

### After

The discrepancies noted above are absent, and all the text is slightly larger.

<img width="964" alt="iPhone X rendering after" src="https://user-images.githubusercontent.com/210406/41823228-d50bf3b8-77fc-11e8-921c-86cfe0611ccd.png">
