### PR TITLE
marked@0.6.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -992,7 +992,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v0.18.1#FiniteNumber for 
 disabled by default if <code>process.env.NODE_ENV</code> is <code>'production'</code>. If this
 rule is unsuitable for a given program, one may use <a href="#create"><code>create</code></a>
 to create a Sanctuary module based on a different rule. For example:</p>
-<pre><code class="lang-javascript"><span class="keyword">const</span> S = sanctuary.create ({
+<pre><code class="language-javascript"><span class="keyword">const</span> S = sanctuary.create ({
   checkTypes: localStorage.getItem (<span class="string-literal">'SANCTUARY_CHECK_TYPES'</span>) === <span class="string-literal">'true'</span>,
   env: sanctuary.env,
 });
@@ -1005,7 +1005,7 @@ via selective use of <a href="#unchecked"><code>unchecked</code></a> functions.<
 <p><code>npm install sanctuary</code> will install Sanctuary for use in Node.js.</p>
 <p>Running Sanctuary in the browser is more involved. One must include a
 <code>&lt;script></code> for each dependency in addition to one for Sanctuary itself:</p>
-<pre><code class="lang-html">&lt;script src=&quot;vendor/sanctuary-show.js&quot;>&lt;/script>
+<pre><code class="language-html">&lt;script src=&quot;vendor/sanctuary-show.js&quot;>&lt;/script>
 &lt;script src=&quot;vendor/sanctuary-type-identifiers.js&quot;>&lt;/script>
 &lt;script src=&quot;vendor/sanctuary-type-classes.js&quot;>&lt;/script>
 &lt;script src=&quot;vendor/sanctuary-either.js&quot;>&lt;/script>
@@ -1017,7 +1017,7 @@ via selective use of <a href="#unchecked"><code>unchecked</code></a> functions.<
 <p>To ensure compatibility one should use the dependency versions specified
 in <strong>package.json</strong>.</p>
 <p>For convenience one could define aliases for various modules:</p>
-<pre><code class="lang-javascript"><span class="keyword">const</span> S = window.sanctuary;
+<pre><code class="language-javascript"><span class="keyword">const</span> S = window.sanctuary;
 <span class="keyword">const</span> $ = window.sanctuaryDef;
 <span class="comment">// ...</span>
 </code></pre>
@@ -1038,7 +1038,7 @@ is enabled, a badly typed application will produce an exception with a
 descriptive error message.</p>
 <p>The following snippet demonstrates defining a custom type and using
 <code>create</code> to produce a Sanctuary module which is aware of that type:</p>
-<pre><code class="lang-javascript"><span class="keyword">const</span> {create, env} = require (<span class="string-literal">'sanctuary'</span>);
+<pre><code class="language-javascript"><span class="keyword">const</span> {create, env} = require (<span class="string-literal">'sanctuary'</span>);
 <span class="keyword">const</span> $ = require (<span class="string-literal">'sanctuary-def'</span>);
 <span class="keyword">const</span> type = require (<span class="string-literal">'sanctuary-type-identifiers'</span>);
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "eslint": "4.9.x",
-    "marked": "0.3.9",
+    "marked": "0.6.1",
     "sanctuary-style": "2.0.x"
   }
 }

--- a/scripts/generate
+++ b/scripts/generate
@@ -81,6 +81,7 @@ const when              = S.when;
 const ESCAPE            = '\u001B';
 const NO_BREAK_SPACE    = '\u00A0';
 const PILCROW_SIGN      = '\u00B6';
+const ZERO_WIDTH_SPACE  = '\u200B';
 const WORD_JOINER       = '\u2060';
 const SYMBOL_FOR_SPACE  = '\u2420';
 
@@ -249,6 +250,7 @@ def ('toOutputMarkup')
                                                    $context,
                                                    {displayErrors: false})),
             either (pipe ([concat ('! '),
+                           replace (/^$/gm) (ZERO_WIDTH_SPACE),
                            Html.encode,
                            Just,
                            el ('div') ({'class': 'output',
@@ -390,14 +392,15 @@ def ('generate')
             replace (regex ('gm') ('^```javascript\\n(> [^]*?)^```\\n'))
                     (($0, $1) => Html.unwrap (doctestsToMarkup ($1))),
             //  Replace NO-BREAK SPACE characters with SYMBOL FOR SPACE
-            //  characters to work around chjj/marked#363.
+            //  characters to work around markedjs/marked#363.
             replace (regex ('g') (NO_BREAK_SPACE)) (SYMBOL_FOR_SPACE),
-            s => marked (s, {pedantic: true}),
+            s => marked (s, {}),
             replace (regex ('g') (SYMBOL_FOR_SPACE)) (NO_BREAK_SPACE),
+            replace (regex ('g') (ZERO_WIDTH_SPACE)) (''),
             replace (/&#39;/g) ("'"),
             replace (/&gt;/g) ('>'),
-            replace (/\n\n(?=\n<[/]code><[/]pre>)/g) (''),
-            replace (regex ('g') ('(<pre><code class="lang-javascript">)([^]*?)(?=</code></pre>)'))
+            replace (regex ('gm') ('(?!^)(?=</code></pre>)')) ('\n'),
+            replace (regex ('g') ('(<pre><code class="language-javascript">)([^]*?)(?=</code></pre>)'))
                     (($0, $1, $2) => $1 + Html.unwrap (highlight (Html ($2)))),
             replace (regex ('gm') ('</code></pre>(?!$)')) ($0 => $0 + '\n'),
             replace (/(?=<(h[2-6]) id="([^"]*)")/g)

--- a/style.css
+++ b/style.css
@@ -196,29 +196,29 @@ pre code {
   color: #c36;
 }
 
-code.lang-javascript {
+code.language-javascript {
   color: #333;
 }
 
-code.lang-javascript .boolean-literal {
+code.language-javascript .boolean-literal {
   color: #963;
 }
 
-code.lang-javascript .comment,
-code.lang-javascript .punctuation {
+code.language-javascript .comment,
+code.language-javascript .punctuation {
   color: #999;
 }
 
-code.lang-javascript .keyword {
+code.language-javascript .keyword {
   color: #c36;
 }
 
-code.lang-javascript .number-literal {
+code.language-javascript .number-literal {
   color: #069;
 }
 
-code.lang-javascript .string-literal,
-code.lang-javascript .template-literal {
+code.language-javascript .string-literal,
+code.language-javascript .template-literal {
   color: #080;
 }
 


### PR DESCRIPTION
These changes require explanation.

In order for fenced code blocks to be treated as such, Marked now requires `pedantic: false` (which is the default). Until now we have used `pedantic: true` to prevent

```html
<div>Foo

Bar

Baz</div>
```

from being rendered as multiple paragraphs. Instead, we now insert ZERO WIDTH SPACE characters to avoid problematic empty lines in the Markdown input. We later remove these characters from the HTML output.

The language prefix is now `language-` rather than `lang-` in accordance with markedjs/marked#1265.
