### PR TITLE
remove redundant client-side redirection

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Sanctuary</title>
-  <script>
-    if (location.hostname.split('.').slice(-2).join('.') === 'github.io') {
-      location.replace('http://sanctuary.js.org' +
-                       location.pathname.replace('/sanctuary-site/', '/') +
-                       location.search +
-                       location.hash);
-    }
-  </script>
   <link rel="stylesheet" href="https://cdn.rawgit.com/tonsky/FiraCode/1.204/distr/fira_code.css">
   <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" href="favicon.png">

--- a/scripts/generate
+++ b/scripts/generate
@@ -564,14 +564,6 @@ def ('toDocument')
 <head>
   <meta charset="utf-8">
   <title>Sanctuary</title>
-  <script>
-    if (location.hostname.split('.').slice(-2).join('.') === 'github.io') {
-      location.replace('http://sanctuary.js.org' +
-                       location.pathname.replace('/sanctuary-site/', '/') +
-                       location.search +
-                       location.hash);
-    }
-  </script>
   <link rel="stylesheet" href="https://cdn.rawgit.com/tonsky/FiraCode/1.204/distr/fira_code.css">
   <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" href="favicon.png">


### PR DESCRIPTION
GitHub now performs server-side redirection:

```console
$ curl -s -I https://sanctuary-js.github.io/sanctuary-site/x/y/z | grep -i location
location: http://sanctuary.js.org/x/y/z
```
