### PR TITLE
fetch Fira Code from Google Fonts rather than from RawGit

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Sanctuary</title>
-  <link rel="stylesheet" href="https://cdn.rawgit.com/tonsky/FiraCode/1.204/distr/fira_code.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Code:400,500,700&display=swap">
   <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" href="favicon.png">
   <link rel="mask-icon" href="mask-icon.svg" color="#080">

--- a/scripts/generate
+++ b/scripts/generate
@@ -564,7 +564,7 @@ def ('toDocument')
 <head>
   <meta charset="utf-8">
   <title>Sanctuary</title>
-  <link rel="stylesheet" href="https://cdn.rawgit.com/tonsky/FiraCode/1.204/distr/fira_code.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Code:400,500,700&display=swap">
   <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" href="favicon.png">
   <link rel="mask-icon" href="mask-icon.svg" color="#080">


### PR DESCRIPTION
[RawGit][1] is slowly being shut down, and Google Fonts now serves [Fira Code][2].


[1]: https://rawgit.com/
[2]: https://fonts.google.com/specimen/Fira+Code
