### PR TITLE
generate: add string replacement functions

### DIFF
--- a/scripts/generate
+++ b/scripts/generate
@@ -47,6 +47,7 @@ const chain             = S.chain;
 const compose           = S.compose;
 const concat            = S.concat;
 const cond              = R.cond;
+const contramap         = S.contramap;
 const curry2            = S.curry2;
 const curry3            = S.curry3;
 const either            = S.either;
@@ -59,9 +60,11 @@ const fork              = Future.fork;
 const fst               = S.fst;
 const get               = S.get;
 const has               = R.has;
+const head              = S.head;
 const ifElse            = S.ifElse;
 const is                = S.is;
 const join              = S.join;
+const justs             = S.justs;
 const lift2             = S.lift2;
 const lift3             = S.lift3;
 const map               = S.map;
@@ -79,14 +82,12 @@ const prop              = S.prop;
 const reduce            = S.reduce;
 const regex             = S.regex;
 const reject            = Future.reject;
-const replace           = R.replace;
 const resolve           = Future.resolve;
 const snd               = S.snd;
 const sort              = S.sort;
 const splitOn           = S.splitOn;
 const splitOnRegex      = S.splitOnRegex;
 const test              = S.test;
-const when              = S.when;
 
 const ESCAPE            = '\u001B';
 const NO_BREAK_SPACE    = '\u00A0';
@@ -107,6 +108,30 @@ def ('fromJust')
     ({})
     ([$.Maybe (a), a])
     (maybe_ (() => { throw new Error ('fromJust applied to Nothing'); }) (I));
+
+//    replace :: RegExp -> String -> String -> String
+const replace =
+def ('replace')
+    ({})
+    ([$.RegExp, $.String, $.String, $.String])
+    (pattern => replacement => text => text.replace (pattern, replacement));
+
+//    replace_ :: RegExp -> (Array (Maybe String) -> String) -> String -> String
+const replace_ =
+def ('replace_')
+    ({})
+    ([$.RegExp,
+      $.Fn ($.Array ($.Maybe ($.String))) ($.String),
+      $.String,
+      $.String])
+    (pattern => substitute => text =>
+       text.replace (pattern, (...args) =>
+         substitute (map (group => group == null ? Nothing : Just (group))
+                         (args.slice (1, -2)))
+       ));
+
+//    replace__ :: RegExp -> (Array String -> String) -> String -> String
+const replace__ = flip (compose (flip (replace_)) (contramap (justs)));
 
 //    wrap :: Semigroup a => a -> a -> a -> a
 const wrap =
@@ -212,9 +237,9 @@ def ('headingToMarkup')
             c === '(' || c === '[' || c === '{' ?
               {t: '', html: wrap (html) (Html.encode (c)) (linkTokens (t)), ctx: ctx + c} :
             c === ')' || c === ']' || c === '}' ?
-              {t: '', html: wrap (html) (Html.encode (c)) (linkTokens (t)), ctx: (ctx.replace (/:$/, '')).slice (0, -1)} :
+              {t: '', html: wrap (html) (Html.encode (c)) (linkTokens (t)), ctx: (replace (/:$/) ('') (ctx)).slice (0, -1)} :
             c === ',' ?
-              {t: '', html: wrap (html) (Html.encode (c)) (linkTokens (t)), ctx: ctx.replace (/:$/, '')} :
+              {t: '', html: wrap (html) (Html.encode (c)) (linkTokens (t)), ctx: replace (/:$/) ('') (ctx)} :
             c === ' ' || c === NO_BREAK_SPACE || c === '?' ?
               {t: '', html: wrap (html) (Html.encode (c)) ((ctx.endsWith ('{') ? Html.encode : linkTokens) (t)), ctx} :
             // else
@@ -391,20 +416,20 @@ const generate =
 def ('generate')
     ({})
     ([$.String, Html.Type])
-    (pipe ([replace (regex ('gm') ('^(#{1,6}) <span id="([^"]*)">❑ (.*)</span>$'))
-                    (($0, $1, $2, $3) => `<h${$1.length} id="${$2}">${$3}</h${$1.length}>`),
-            replace (regex ('gm') ('^#### <a name="(.*)" href="(.*)">`(.*)`</a>$'))
-                    (($0, $1, $2, $3) => Html.unwrap (headingToMarkup ($1) ($2) ($3))),
-            replace (regex ('gm') ('^```javascript\\n(> [^]*?)^```\\n'))
-                    (($0, $1) => Html.unwrap (doctestsToMarkup ($1))),
+    (pipe ([replace__ (regex ('gm') ('^(#{1,6}) <span id="([^"]*)">❑ (.*)</span>$'))
+                      (([$1, $2, $3]) => `<h${$1.length} id="${$2}">${$3}</h${$1.length}>`),
+            replace__ (regex ('gm') ('^#### <a name="(.*)" href="(.*)">`(.*)`</a>$'))
+                      (([$1, $2, $3]) => Html.unwrap (headingToMarkup ($1) ($2) ($3))),
+            replace__ (regex ('gm') ('^```javascript\\n(> [^]*?)^```\\n'))
+                      (([$1]) => Html.unwrap (doctestsToMarkup ($1))),
             s => marked (s, {}),
             replace (regex ('g') (ZERO_WIDTH_SPACE)) (''),
             replace (/&#39;/g) ("'"),
             replace (/&gt;/g) ('>'),
             replace (regex ('gm') ('(?!^)(?=</code></pre>)')) ('\n'),
-            replace (regex ('g') ('(<pre><code class="language-javascript">)([^]*?)(?=</code></pre>)'))
-                    (($0, $1, $2) => $1 + Html.unwrap (highlight (Html ($2)))),
-            replace (regex ('gm') ('</code></pre>(?!$)')) ($0 => $0 + '\n'),
+            replace__ (regex ('g') ('(<pre><code class="language-javascript">)([^]*?)(?=</code></pre>)'))
+                      (([$1, $2]) => $1 + Html.unwrap (highlight (Html ($2)))),
+            replace (regex ('gm') ('</code></pre>(?!$)')) ('$&\n'),
             replace (regex ('g') ('<(h[2-6]) id="([^"]*)">(.*)</\\1>\n*'))
                     ('<a class="pilcrow $1" href="#$2">' + PILCROW_SIGN + '</a>\n' +
                      '<$1 id="$2">$3</$1>\n'),
@@ -452,7 +477,7 @@ def ('customize')
                           (K (reject ('Expected exactly one separator')))),
             map (([existing, replacement]) =>
                    s => s.includes (existing) ?
-                        resolve (replace (existing) (replacement) (s)) :
+                        resolve (s.replace (existing, replacement)) :
                         reject ('Substring not found:\n\n' + existing))]));
 
 //    readme :: String -> Future String String
@@ -495,14 +520,15 @@ def ('tocListItem')
     ({})
     ([Heading, Html.Type])
     (function recur({level, id, html, subheads}) {
+       const pattern = '<a [^>]*>([^<]*)</a>';
        const a = el ('a')
                     ({href: '#' + id})
-                    (Just (Html (Html.unwrap (html)
-                                 .replace (/<a [^>]*>([^<]*)<[/]a>/g,
-                                           ($0, $1, idx) =>
-                                             when (K (idx === '<code>'.length))
-                                                  (wrap ('<b>') ('</b>'))
-                                                  ($1)))));
+                    (pipe ([Html.unwrap,
+                            replace (regex ('') (pattern)) ('<b>$1</b>'),
+                            replace (regex ('g') (pattern)) ('$1'),
+                            Html,
+                            Just])
+                          (html));
        return Html.indent (4) (reduce (concat) (empty (Html)) (join (join ([
          [[Html ('<li>\n')]],
          subheads.length === 0 ?
@@ -528,20 +554,19 @@ const toc =
 def ('toc')
     ({})
     ([$.String, Html.Type])
-    (pipe ([matchAll (/<(h[1-6]) id="([^"]*)">(.*)<[/]\1>/g),
+    (pipe ([matchAll (/<h([1-6]) id="([^"]*)">(.*)<[/]h\1>/g),
             map (prop ('groups')),
-            map (map (fromJust)),
-            reduce (heading => ([tagName, id, s]) => {
-                      const level = Number (replace ('h', '', tagName));
-                      for (let subheads = heading.subheads;
-                           true;
-                           subheads = subheads[subheads.length - 1].subheads) {
-                        if (subheads.length === 0 ||
-                            subheads[0].level === level) {
-                          subheads.push ({level, id, html: Html (s), subheads: []});
-                          return heading;
-                        }
+            map (justs),
+            reduce (heading => ([_level, id, s]) => {
+                      const level = Number (_level);
+                      let {subheads} = heading;
+                      while (maybe (false)
+                                   (heading => heading.level !== level)
+                                   (head (subheads))) {
+                        ({subheads} = subheads[subheads.length - 1]);
                       }
+                      subheads.push ({level, id, html: Html (s), subheads: []});
+                      return heading;
                     })
                    ({level: 1, id: '', html: empty (Html), subheads: []}),
             prop ('subheads'),


### PR DESCRIPTION
Shortly I will submit a pull request to propose the addition of the following two functions to Sanctuary:

```haskell
replace  :: RegExp ->                          String  -> String -> String
replace_ :: RegExp -> (Array (Maybe String) -> String) -> String -> String
```

I am submitting this pull request to provide reviewers of the forthcoming Sanctuary pull request with realistic usage examples.
