### PR TITLE
sponsor: add Fink

### DIFF
--- a/custom/sponsors.md
+++ b/custom/sponsors.md
@@ -4,7 +4,56 @@
 
 ## <span id="section:sponsors">❑ Sponsors</span>
 
-Development of Sanctuary is encouraged by the following generous supporters:
+Development of Sanctuary is funded by the following community-minded
+__partners__:
+
+  - <p>
+      <a id="logo-fink" href="https://www.fink.no/">
+        <svg viewBox="0 0 100 44" xmlns="http://www.w3.org/2000/svg">
+          <shell>
+            curl --silent https://www.fink.no/images/fink.svg \
+            | sed -E -n 's,<path d="([^"]*)" fill="[^"]*"/>,\1,p' \
+            | sed -E 's,([A-Z]), \1 ,g' \
+            | xargs node --eval '
+              let idx = 1;
+              const next = () => process.argv[idx++];
+              const vert = () => (next () * 1e6 + 44 * 1e6 - 43.5185 * 1e6) / 1e6;
+              const tokens = [];
+              while (idx < process.argv.length) {
+                switch (process.argv[idx]) {
+                  case "M":
+                  case "L":
+                    tokens.push (next (), next (), vert ());
+                    break;
+                  case "H":
+                    tokens.push (next (), next ());
+                    break;
+                  case "V":
+                    tokens.push (next (), vert ());
+                    break;
+                  case "C":
+                    tokens.push (next (), next (), vert (), next (), vert (), next (), vert ());
+                    break;
+                  case "Z":
+                    tokens.push (next ());
+                    break;
+                }
+              }
+              process.stdout.write (`<path d="${tokens.join (" ")}" />`);
+            '
+          </shell>
+        </svg>
+      </a>
+      is a small, friendly, and passionate gang of IT consultants.
+      We love what we do, which is mostly web and app development,
+      including graphic design, interaction design, back-end and
+      front-end coding, and ensuring the stuff we make works as intended.
+      Our company is entirely employee-owned; we place great importance on
+      the well-being of every employee, both professionally and personally.
+    </p>
+
+Development of Sanctuary is further encouraged by the following generous
+__supporters__:
 
   - [@voxbono](https://github.com/voxbono)
   - [@syves](https://github.com/syves)

--- a/index.html
+++ b/index.html
@@ -746,7 +746,27 @@ In JavaScript it's trivial to introduce a possible run-time type error.</p>
 <p>Sanctuary is designed to work in Node.js and in ES5-compatible browsers.</p>
 <a class="pilcrow h2" href="#section:sponsors">¶</a>
 <h2 id="section:sponsors">Sponsors</h2>
-<p>Development of Sanctuary is encouraged by the following generous supporters:</p>
+<p>Development of Sanctuary is funded by the following community-minded
+<strong>partners</strong>:</p>
+<ul>
+<li><p>
+  <a id="logo-fink" href="https://www.fink.no/">
+    <svg viewBox="0 0 100 44" xmlns="http://www.w3.org/2000/svg">
+      <path d="M 13.5 13.9872 H 33.25 V 44 H 25.5 V 19.7397 H 13.5 V 44 H 5.75 V 19.7397 H 0 V 13.9872 H 5.75 C 5.75 9.73544 7 6.48405 9.25 4.2331 C 11.5 1.98214 15 0.731606 19.5 0.4815 H 22.25 L 22.5 6.23395 H 19.5 C 17.5 6.48405 15.75 6.98427 14.75 7.98469 C 14 8.98512 13.5 10.4858 13.5 12.4866 V 13.9872 Z M 63 16.2382 C 64.75 18.2391 65.75 21.4904 65.75 25.4921 V 44 H 58 V 25.9924 C 58 23.7414 57.5 21.9907 56.75 20.9902 C 55.75 19.9898 54.5 19.4896 52.5 19.4896 C 50.25 19.4896 48.5 20.2399 47.25 21.4904 C 46 22.9911 45.25 24.7418 45.25 26.9928 V 44 H 37.5 V 13.9873 H 45 V 18.4892 C 46 16.7384 47.5 15.4879 49 14.7376 C 50.75 13.7371 52.75 13.487 54.75 13.487 C 58.75 13.2369 61.25 14.2374 63 16.2382 Z M 100 44 H 90.5 L 77.5 30.2441 V 44 H 70 V 0.731592 H 77.5 V 27.2429 L 89.5 14.2373 H 98.75 L 85.25 28.7435 L 100 44 Z" />
+    </svg>
+  </a>
+  is a small, friendly, and passionate gang of IT consultants.
+  We love what we do, which is mostly web and app development,
+  including graphic design, interaction design, back-end and
+  front-end coding, and ensuring the stuff we make works as intended.
+  Our company is entirely employee-owned; we place great importance on
+  the well-being of every employee, both professionally and personally.
+</p>
+
+</li>
+</ul>
+<p>Development of Sanctuary is further encouraged by the following generous
+<strong>supporters</strong>:</p>
 <ul>
 <li><a href="https://github.com/voxbono">@voxbono</a></li>
 <li><a href="https://github.com/syves">@syves</a></li>

--- a/scripts/generate
+++ b/scripts/generate
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const {execSync}        = require ('child_process');
 const fs                = require ('fs');
 const path              = require ('path');
 const vm                = require ('vm');
@@ -478,7 +479,11 @@ def ('customize')
                           (K (reject ('Expected exactly one separator')))),
             map (([existing, replacement]) =>
                    s => s.includes (existing) ?
-                        resolve (s.replace (existing, replacement)) :
+                        map (replacement => s.replace (existing, replacement))
+                            (encaseFuture (replace (contramap (justs)
+                                                              (([$1]) => execSync ($1, {encoding: 'utf8'})))
+                                                   (regex ('g') ('<shell>([^]*?)</shell>')))
+                                          (replacement)) :
                         reject ('Substring not found:\n\n' + existing))]));
 
 //    readme :: String -> Future String String

--- a/style.css
+++ b/style.css
@@ -290,3 +290,18 @@ strong {
   text-align: center;
   color: #eee;
 }
+
+#logo-fink {
+  background: none;
+}
+
+#logo-fink svg {
+  margin-top: -10px;
+  height: 1.524em;
+  fill: #f0885d;
+}
+
+#logo-fink:focus svg,
+#logo-fink:hover svg {
+  fill: #454d60;
+}


### PR DESCRIPTION
Many thanks to [Fink][1] for their generous support! :tada:

Thanks also to @voxbono for encouraging Fink to contribute financially to the development of Sanctuary. :clap:

---

![Sanctuary sponsors](https://user-images.githubusercontent.com/210406/97496861-e8a01d80-1969-11eb-8e4e-f981942affda.png)

---

In order to control the hover styling of the Fink logo, I used an inline SVG (rather than referencing [__fink.svg__][2] from an `<img>`).

As can be seen in the screenshot above, the Fink logo acts as the first word of the paragraph about Fink. The baseline of the Fink logo should be aligned with the baseline of the surrounding text. Unfortunately the source file has a tiny gap between the baseline and the edge of the `viewBox`. To remove this gap I adjusted the `path` of the `<svg>`, moving all the y-coordinates down by the difference between the bottom of the `viewBox` (`44`) and the baseline (`43.5185`). Behold the alignment!

I am an advocate of makefiles as I appreciate having a record of how files are derived from various sources. Make is not suitable in this case, though, as the SVG appears inline in an HTML file. I decided to add a new capability to `generate`: replacement strings can now include arbitrary shell commands between `<shell>` and `</shell>`, which are executed to determine what should appear in place of the `<shell>` elements. I used this capability to record the logo tweaks.

@voxbono, please review the Fink-specific additions. :)


[1]: https://www.fink.no/
[2]: https://www.fink.no/images/fink.svg
