### PR TITLE
style: use ::marker to style disclosure triangles

### DIFF
--- a/style.css
+++ b/style.css
@@ -122,8 +122,14 @@ a code {
 #toc details summary::-webkit-details-marker {
   color: #999;
 }
+#toc details summary::marker {
+  color: #999;
+}
 
 #toc details summary:focus::-webkit-details-marker {
+  color: #080;
+}
+#toc details summary:focus::marker {
   color: #080;
 }
 


### PR DESCRIPTION
[Feature: `display: list-item` by default for `<summary>`][1]

This pull request restores the desired styling of disclosure triangles in Google Chrome.


[1]: https://chromestatus.com/feature/6730096436051968
