### PR TITLE
eslint: use "readonly" for globals in place of deprecated value

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   "overrides": [
     {
       "files": ["adt/*.js", "env.js"],
-      "globals": {"module": false, "require": false, "self": false}
+      "globals": {"module": "readonly", "require": "readonly", "self": "readonly"}
     },
     {
       "files": ["behaviour.js"],


### PR DESCRIPTION
Relates to sanctuary-js/sanctuary-style#33
